### PR TITLE
PoC TAP Editor

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -317,6 +317,22 @@
             "navigationTitle": "Audio Playlists",
             "title": "Tonie Audio Playlists"
         },
+        "tapEditor": {
+            "titleEdit": "TAP bearbeiten",
+            "titleCreate": "Neue TAP erstellen",
+            "save": "Speichern",
+            "create": "Anlegen",
+            "cancel": "Abbrechen",
+            "filePath": "Dateipfad Playlist",
+            "filePathRequired": "Der Dateipfad Playlist muss ausgefüllt werden",
+            "name": "TAP Name",
+            "nameRequired": "Der TAP Name muss ausgefüllt werden",
+            "filePathContentFile": "Dateipfad",
+            "filePathContentFileRequired": "Der Dateipfad muss ausgefüllt werden",
+            "fileNameContentFile": "Dateiname",
+            "fileNameContentFileRequired": "Der Dateiname muss ausgefüllt werden",
+            "addFile": "Datei hinzufügen"
+        },
         "title": "Tonies",
         "tonies": {
             "filterBar": {

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -329,8 +329,7 @@
             "nameRequired": "Der TAP Name muss ausgefüllt werden",
             "filePathContentFile": "Dateipfad",
             "filePathContentFileRequired": "Der Dateipfad muss ausgefüllt werden",
-            "fileNameContentFile": "Dateiname",
-            "fileNameContentFileRequired": "Der Dateiname muss ausgefüllt werden",
+            "fileNameContentFile": "Beschreibung",
             "addFile": "Datei hinzufügen"
         },
         "title": "Tonies",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -316,6 +316,22 @@
             "navigationTitle": "Audio Playlists",
             "title": "Tonie Audio Playlists"
         },
+        "tapEditor": {
+            "titleEdit": "Edit TAP",
+            "titleCreate": "Create new TAP",
+            "save": "Save",
+            "create": "Create",
+            "cancel": "Cancel",
+            "filePath": "File path Playlist",
+            "filePathRequired": "File path Playlist must be set",
+            "name": "TAP Name",
+            "nameRequired": "TAP Name  must be set",
+            "filePathContentFile": "File path",
+            "filePathContentFileRequired": "File path must be set",
+            "fileNameContentFile": "File name",
+            "fileNameContentFileRequired": "file name must be set",
+            "addFile": "Add file"
+        },
         "title": "Tonies",
         "tonies": {
             "filterBar": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -328,8 +328,7 @@
             "nameRequired": "TAP Name  must be set",
             "filePathContentFile": "File path",
             "filePathContentFileRequired": "File path must be set",
-            "fileNameContentFile": "File name",
-            "fileNameContentFileRequired": "file name must be set",
+            "fileNameContentFile": "Description",
             "addFile": "Add file"
         },
         "title": "Tonies",

--- a/src/components/tonies/FileBrowser.tsx
+++ b/src/components/tonies/FileBrowser.tsx
@@ -20,6 +20,7 @@ import { humanFileSize } from "../../util/humanFileSize";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import ConfirmationDialog from "../ConfirmationDialog";
+import TonieAudioPlaylistEditor from "./TonieAudioPlaylistEditor";
 
 export const FileBrowser: React.FC<{
     special: string;
@@ -57,9 +58,15 @@ export const FileBrowser: React.FC<{
 
     const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
 
-    const [jsonData, setJsonData] = useState(null);
+    const [jsonData, setJsonData] = useState<string>("");
     const [jsonViewerModalOpened, setJsonViewerModalOpened] = useState(false);
+    const [showTAPEditor, setShowTAPEditor] = useState(false);
+    const [tapEditorKey, setTapEditorKey] = useState(0);
 
+    const onCreate = (values: any) => {
+        console.log("Received values of form: ", values);
+        setShowTAPEditor(false);
+    };
     const fetchJsonData = async (url: string) => {
         try {
             const response = await fetch(url);
@@ -422,7 +429,10 @@ export const FileBrowser: React.FC<{
                 if (isTapList && record.name.includes(".tap")) {
                     actions.push(
                         <Tooltip title={t("fileBrowser.tap.edit")}>
-                            <EditOutlined style={{ margin: "0 16px 0 0" }} />
+                            <EditOutlined
+                                style={{ margin: "0 16px 0 0" }}
+                                onClick={() => handleEditTapClick(path + "/" + record.name)}
+                            />
                         </Tooltip>
                     );
                     actions.push(
@@ -489,6 +499,16 @@ export const FileBrowser: React.FC<{
         </Button>
     );
 
+    const handleEditTapClick = (file: string) => {
+        if (file.includes(".tap")) {
+            const folder = special === "library" ? "/library" : "/content";
+            fetchJsonData(process.env.REACT_APP_TEDDYCLOUD_API_URL + folder + file);
+            setCurrentFile(file);
+            setTapEditorKey((prevKey) => prevKey + 1);
+            setShowTAPEditor(true);
+        }
+    };
+
     return (
         <>
             {contextHolder}
@@ -548,6 +568,15 @@ export const FileBrowser: React.FC<{
                           }
                         : undefined
                 }
+            />
+            <TonieAudioPlaylistEditor
+                open={showTAPEditor}
+                key={tapEditorKey}
+                initialValuesJson={jsonData ? JSON.stringify(jsonData, null, 2) : undefined}
+                onCreate={onCreate}
+                onCancel={() => {
+                    setShowTAPEditor(false);
+                }}
             />
         </>
     );

--- a/src/components/tonies/TonieAudioPlaylistEditor.tsx
+++ b/src/components/tonies/TonieAudioPlaylistEditor.tsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useState } from "react";
+import { Modal, Form, Input, Button, Space } from "antd";
+import { CloseOutlined, FolderOpenOutlined, MinusCircleOutlined, PlusOutlined } from "@ant-design/icons";
+import { useTranslation } from "react-i18next";
+import { FileBrowser } from "./FileBrowser";
+
+export interface FileItem {
+    filepath: string;
+    name: string;
+}
+
+export interface FormValues {
+    type: string;
+    audio_id: number;
+    filepath: string;
+    name: string;
+    files: FileItem[];
+}
+
+export interface TonieAudioPlaylistEditorProps {
+    open: boolean;
+    initialValuesJson?: string;
+    onCreate: (values: FormValues) => void;
+    onCancel: () => void;
+}
+
+const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
+    open,
+    initialValuesJson,
+    onCreate,
+    onCancel,
+}) => {
+    const { t } = useTranslation();
+    const [form] = Form.useForm<FormValues>();
+    const [selectedFiles, setSelectedFiles] = useState<FileItem[]>([]);
+    const [isSelectFileModalOpen, setSelectFileModalOpen] = useState(false);
+    const [filebrowserKey, setFilebrowserKey] = useState(0); // Key for modal rendering
+    const [selectedFileIndex, setSelectedFileIndex] = useState<number>(-1);
+
+    const resetForm = () => {
+        form.resetFields();
+    };
+    useEffect(() => {
+        setSelectedFiles([]);
+    }, []);
+
+    useEffect(() => {
+        // Set initial values when initialValuesJson prop changes
+        if (initialValuesJson) {
+            try {
+                const initialValues = JSON.parse(initialValuesJson);
+                form.setFieldsValue(initialValues);
+            } catch (error) {
+                console.error("Error parsing JSON:", error);
+            }
+        }
+    }, [form, initialValuesJson]);
+
+    const handleSourceInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        form.setFieldsValue({ filepath: e.target.value });
+    };
+
+    const handleFileSelectChange = (files: any[], path: string, special: string) => {
+        if (files && files.length > 0) {
+            const prefix = special === "library" ? "lib:/" : "content:/";
+            const newFiles = files.map((file) => ({
+                filepath: prefix + path + "/" + file.name,
+                name: file.name,
+            }));
+            setSelectedFiles(newFiles);
+        }
+    };
+
+    const showFileSelectModal = () => {
+        setFilebrowserKey((prevKey) => prevKey + 1);
+        setSelectFileModalOpen(true);
+    };
+
+    const handleEditFile = (index: number) => {
+        setFilebrowserKey((prevKey) => prevKey + 1);
+        setSelectFileModalOpen(true);
+        setSelectedFileIndex(index); // Store the index of the selected file
+        setSelectedFiles([form.getFieldValue(["files", index])]);
+    };
+
+    const handleOkSelectFile = () => {
+        const currentValues = form.getFieldsValue() as FormValues;
+        let updatedFiles = [...currentValues.files];
+
+        if (selectedFileIndex !== -1) {
+            // Replace existing file
+            updatedFiles[selectedFileIndex] = {
+                filepath: selectedFiles[0].filepath,
+                name: selectedFiles[0].name,
+            };
+        } else {
+            // Add new file
+            updatedFiles = [...currentValues.files, ...selectedFiles];
+        }
+
+        const updatedValues = {
+            ...currentValues,
+            files: updatedFiles,
+        };
+
+        form.setFieldsValue(updatedValues);
+
+        setSelectFileModalOpen(false);
+        setSelectedFiles([]);
+        setSelectedFileIndex(-1); // Reset selected file index
+    };
+
+    const handleCancelSelectFile = () => {
+        setSelectFileModalOpen(false);
+        setSelectedFiles([]);
+    };
+
+    return (
+        <Modal
+            open={open}
+            title={initialValuesJson ? t("tonies.tapEditor.titleEdit") : t("tonies.tapEditor.titleCreate")}
+            okText={initialValuesJson ? t("tonies.tapEditor.save") : t("tonies.tapEditor.create")}
+            cancelText="Cancel"
+            onCancel={() => {
+                onCancel();
+                resetForm();
+            }}
+            onOk={() => {
+                form.validateFields()
+                    .then(() => {
+                        onCreate(form.getFieldsValue() as FormValues);
+                        resetForm();
+                    })
+                    .catch((info) => {
+                        console.log("Validate Failed:", info);
+                    });
+            }}
+        >
+            <Form
+                form={form}
+                layout="vertical"
+                name="tapEditorModal"
+                initialValues={{
+                    type: "tap",
+                    filepath: "",
+                    name: "",
+                    files: [],
+                }}
+            >
+                <Form.Item name="audio_id" label="Audio ID">
+                    <Input type="number" />
+                </Form.Item>
+                <Form.Item name="filepath" label={t("tonies.tapEditor.filePath")}>
+                    <Input onChange={handleSourceInputChange} />
+                </Form.Item>
+                <Form.Item
+                    name="name"
+                    label={t("tonies.tapEditor.name")}
+                    rules={[{ required: true, message: t("tonies.tapEditor.nameRequired") }]}
+                >
+                    <Input />
+                </Form.Item>
+
+                <Form.List name="files">
+                    {(fields, { add, remove }) => (
+                        <>
+                            {fields.map(({ key, name }, index) => (
+                                <Space
+                                    key={key}
+                                    style={{ display: "flex", marginBottom: 8, alignItems: "center", width: "100%" }}
+                                    align="baseline"
+                                >
+                                    <Form.Item
+                                        name={[name, "filepath"]}
+                                        label={t("tonies.tapEditor.filePathContentFile")}
+                                        rules={[
+                                            {
+                                                required: true,
+                                                message: t("tonies.tapEditor.filePathContentFileRequired"),
+                                            },
+                                        ]}
+                                    >
+                                        <Input
+                                            width="auto"
+                                            addonBefore={
+                                                <CloseOutlined
+                                                    onClick={() => {
+                                                        const newValues = [...form.getFieldsValue().files];
+                                                        newValues[index].filepath = "";
+                                                        form.setFieldsValue({ files: newValues });
+                                                    }}
+                                                />
+                                            }
+                                            addonAfter={<FolderOpenOutlined onClick={() => handleEditFile(index)} />}
+                                        />
+                                    </Form.Item>
+                                    <Form.Item
+                                        name={[name, "name"]}
+                                        label={t("tonies.tapEditor.fileNameContentFile")}
+                                        rules={[
+                                            {
+                                                required: true,
+                                                message: t("tonies.tapEditor.fileNameContentFileRequired"),
+                                            },
+                                        ]}
+                                    >
+                                        <Input placeholder="Name" />
+                                    </Form.Item>
+                                    <MinusCircleOutlined onClick={() => remove(name)} />
+                                </Space>
+                            ))}
+                            <Form.Item>
+                                <Button
+                                    type="dashed"
+                                    onClick={() => showFileSelectModal()}
+                                    block
+                                    icon={<PlusOutlined />}
+                                >
+                                    {t("tonies.tapEditor.addFile")}
+                                </Button>
+                            </Form.Item>
+                        </>
+                    )}
+                </Form.List>
+            </Form>
+            <Modal
+                title={t("tonies.selectFileModal.selectFile")}
+                open={isSelectFileModalOpen}
+                onOk={handleOkSelectFile}
+                onCancel={handleCancelSelectFile}
+                width="auto"
+            >
+                <FileBrowser
+                    maxSelectedRows={99}
+                    special="library"
+                    trackUrl={false}
+                    key={filebrowserKey}
+                    onFileSelectChange={handleFileSelectChange}
+                />
+            </Modal>
+        </Modal>
+    );
+};
+
+export default TonieAudioPlaylistEditor;

--- a/src/components/tonies/TonieAudioPlaylistEditor.tsx
+++ b/src/components/tonies/TonieAudioPlaylistEditor.tsx
@@ -34,12 +34,9 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
     const [form] = Form.useForm<FormValues>();
     const [selectedFiles, setSelectedFiles] = useState<FileItem[]>([]);
     const [isSelectFileModalOpen, setSelectFileModalOpen] = useState(false);
-    const [filebrowserKey, setFilebrowserKey] = useState(0); // Key for modal rendering
+    const [filebrowserKey, setFilebrowserKey] = useState(0);
     const [selectedFileIndex, setSelectedFileIndex] = useState<number>(-1);
 
-    const resetForm = () => {
-        form.resetFields();
-    };
     useEffect(() => {
         setSelectedFiles([]);
     }, []);
@@ -55,6 +52,10 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
             }
         }
     }, [form, initialValuesJson]);
+
+    const resetForm = () => {
+        form.resetFields();
+    };
 
     const handleSourceInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         form.setFieldsValue({ filepath: e.target.value });
@@ -120,7 +121,7 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
             open={open}
             title={initialValuesJson ? t("tonies.tapEditor.titleEdit") : t("tonies.tapEditor.titleCreate")}
             okText={initialValuesJson ? t("tonies.tapEditor.save") : t("tonies.tapEditor.create")}
-            cancelText="Cancel"
+            cancelText={t("tonies.tapEditor.cancel")}
             onCancel={() => {
                 onCancel();
                 resetForm();
@@ -165,7 +166,7 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
                     {(fields, { add, remove }) => (
                         <>
                             {fields.map(({ key, name }, index) => (
-                                <div className="playlistTitle" style={{ padding: 8, border: "solid" }}>
+                                <div className="playlistTitle">
                                     <Space
                                         key={key}
                                         style={{
@@ -205,12 +206,6 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
                                         <Form.Item
                                             name={[name, "name"]}
                                             label={t("tonies.tapEditor.fileNameContentFile")}
-                                            rules={[
-                                                {
-                                                    required: true,
-                                                    message: t("tonies.tapEditor.fileNameContentFileRequired"),
-                                                },
-                                            ]}
                                         >
                                             <Input placeholder="Name" />
                                         </Form.Item>

--- a/src/components/tonies/TonieAudioPlaylistEditor.tsx
+++ b/src/components/tonies/TonieAudioPlaylistEditor.tsx
@@ -165,49 +165,58 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
                     {(fields, { add, remove }) => (
                         <>
                             {fields.map(({ key, name }, index) => (
-                                <Space
-                                    key={key}
-                                    style={{ display: "flex", marginBottom: 8, alignItems: "center", width: "100%" }}
-                                    align="baseline"
-                                >
-                                    <Form.Item
-                                        name={[name, "filepath"]}
-                                        label={t("tonies.tapEditor.filePathContentFile")}
-                                        rules={[
-                                            {
-                                                required: true,
-                                                message: t("tonies.tapEditor.filePathContentFileRequired"),
-                                            },
-                                        ]}
+                                <div className="playlistTitle" style={{ padding: 8, border: "solid" }}>
+                                    <Space
+                                        key={key}
+                                        style={{
+                                            display: "flex",
+                                            marginBottom: 8,
+                                            alignItems: "center",
+                                            width: "100%",
+                                        }}
+                                        align="baseline"
                                     >
-                                        <Input
-                                            width="auto"
-                                            addonBefore={
-                                                <CloseOutlined
-                                                    onClick={() => {
-                                                        const newValues = [...form.getFieldsValue().files];
-                                                        newValues[index].filepath = "";
-                                                        form.setFieldsValue({ files: newValues });
-                                                    }}
-                                                />
-                                            }
-                                            addonAfter={<FolderOpenOutlined onClick={() => handleEditFile(index)} />}
-                                        />
-                                    </Form.Item>
-                                    <Form.Item
-                                        name={[name, "name"]}
-                                        label={t("tonies.tapEditor.fileNameContentFile")}
-                                        rules={[
-                                            {
-                                                required: true,
-                                                message: t("tonies.tapEditor.fileNameContentFileRequired"),
-                                            },
-                                        ]}
-                                    >
-                                        <Input placeholder="Name" />
-                                    </Form.Item>
-                                    <MinusCircleOutlined onClick={() => remove(name)} />
-                                </Space>
+                                        <Form.Item
+                                            name={[name, "filepath"]}
+                                            label={t("tonies.tapEditor.filePathContentFile")}
+                                            rules={[
+                                                {
+                                                    required: true,
+                                                    message: t("tonies.tapEditor.filePathContentFileRequired"),
+                                                },
+                                            ]}
+                                        >
+                                            <Input
+                                                width="auto"
+                                                addonBefore={
+                                                    <CloseOutlined
+                                                        onClick={() => {
+                                                            const newValues = [...form.getFieldsValue().files];
+                                                            newValues[index].filepath = "";
+                                                            form.setFieldsValue({ files: newValues });
+                                                        }}
+                                                    />
+                                                }
+                                                addonAfter={
+                                                    <FolderOpenOutlined onClick={() => handleEditFile(index)} />
+                                                }
+                                            />
+                                        </Form.Item>
+                                        <Form.Item
+                                            name={[name, "name"]}
+                                            label={t("tonies.tapEditor.fileNameContentFile")}
+                                            rules={[
+                                                {
+                                                    required: true,
+                                                    message: t("tonies.tapEditor.fileNameContentFileRequired"),
+                                                },
+                                            ]}
+                                        >
+                                            <Input placeholder="Name" />
+                                        </Form.Item>
+                                        <MinusCircleOutlined onClick={() => remove(name)} />
+                                    </Space>
+                                </div>
                             ))}
                             <Form.Item>
                                 <Button
@@ -234,6 +243,7 @@ const TonieAudioPlaylistEditor: React.FC<TonieAudioPlaylistEditorProps> = ({
                     maxSelectedRows={99}
                     special="library"
                     trackUrl={false}
+                    selectTafOnly={false}
                     key={filebrowserKey}
                     onFileSelectChange={handleFileSelectChange}
                 />

--- a/src/components/tonies/TonieCard.tsx
+++ b/src/components/tonies/TonieCard.tsx
@@ -10,7 +10,7 @@ import {
     SaveFilled,
 } from "@ant-design/icons";
 import { Button, Card, Divider, Input, Modal, Tooltip, Typography, message, theme } from "antd";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAudioContext } from "../audio/AudioContext";
 import { FileBrowser } from "./FileBrowser";

--- a/src/components/tonies/TonieCard.tsx
+++ b/src/components/tonies/TonieCard.tsx
@@ -79,7 +79,7 @@ export const TonieCard: React.FC<{
     const { playAudio } = useAudioContext();
     const [isInformationModalOpen, setInformationModalOpen] = useState(false);
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-    const [isSelectFileModalOpen, seSelectFileModalOpen] = useState(false);
+    const [isSelectFileModalOpen, setSelectFileModalOpen] = useState(false);
 
     const [activeModel, setActiveModel] = useState(localTonieCard.tonieInfo.model);
     const [selectedModel, setSelectedModel] = useState("");
@@ -109,12 +109,12 @@ export const TonieCard: React.FC<{
     };
 
     const showFileSelectModal = () => {
-        seSelectFileModalOpen(true);
+        setSelectFileModalOpen(true);
     };
 
     const handleCancelSelectFile = () => {
         setSelectedSource(activeSource);
-        seSelectFileModalOpen(false);
+        setSelectFileModalOpen(false);
     };
 
     const showModelModal = () => {
@@ -485,7 +485,7 @@ export const TonieCard: React.FC<{
         <Modal
             title={t("tonies.selectFileModal.selectFile")}
             open={isSelectFileModalOpen}
-            onOk={() => seSelectFileModalOpen(false)}
+            onOk={() => setSelectFileModalOpen(false)}
             onCancel={handleCancelSelectFile}
             width="auto"
         >

--- a/src/pages/tonies/TonieAudioPlaylistsPage.tsx
+++ b/src/pages/tonies/TonieAudioPlaylistsPage.tsx
@@ -7,13 +7,22 @@ import {
     StyledSider,
 } from "../../components/StyledComponents";
 import { ToniesSubNav } from "../../components/tonies/ToniesSubNav";
-import { Alert, Typography } from "antd";
+import { Alert, Button, Typography } from "antd";
 import { FileBrowser } from "../../components/tonies/FileBrowser";
+import TonieAudioPlaylistEditor from "../../components/tonies/TonieAudioPlaylistEditor";
+import { useState } from "react";
 
 const { Paragraph } = Typography;
 
 export const TonieAudioPlaylistsPage = () => {
     const { t } = useTranslation();
+    const [visible, setVisible] = useState(false);
+    const [filebrowserKey, setFilebrowserKey] = useState(0); // Key for modal rendering
+
+    const onCreate = (values: any) => {
+        console.log("Received values of form: ", values);
+        setVisible(false);
+    };
 
     return (
         <>
@@ -50,6 +59,25 @@ export const TonieAudioPlaylistsPage = () => {
                             showColumns={["name", "size", "date", "controls"]}
                             isTapList={true}
                         />
+                    </Paragraph>
+                    <Paragraph>
+                        <div>
+                            <Button
+                                type="primary"
+                                onClick={() => {
+                                    setVisible(true);
+                                }}
+                            >
+                                {t("tonies.tapEditor.titleCreate")}
+                            </Button>
+                            <TonieAudioPlaylistEditor
+                                open={visible}
+                                onCreate={onCreate}
+                                onCancel={() => {
+                                    setVisible(false);
+                                }}
+                            />
+                        </div>
                     </Paragraph>
                 </StyledContent>
             </StyledLayout>

--- a/src/pages/tonies/TonieAudioPlaylistsPage.tsx
+++ b/src/pages/tonies/TonieAudioPlaylistsPage.tsx
@@ -17,7 +17,6 @@ const { Paragraph } = Typography;
 export const TonieAudioPlaylistsPage = () => {
     const { t } = useTranslation();
     const [visible, setVisible] = useState(false);
-    const [filebrowserKey, setFilebrowserKey] = useState(0); // Key for modal rendering
 
     const onCreate = (values: any) => {
         console.log("Received values of form: ", values);


### PR DESCRIPTION
Added a PoC of the TAP Editor. Currently only a better viewer, nothing happens in save or create.

you can either pass an existing TAP json:

![image](https://github.com/toniebox-reverse-engineering/teddycloud_web/assets/166761451/b3f1ce96-c102-4e38-b053-c415cb19b5e9)

or create a new one:
![image](https://github.com/toniebox-reverse-engineering/teddycloud_web/assets/166761451/5feec75e-7df7-4b30-b349-f3b046c2f4af)

Add new files opens the filebrowser and you can add multiple files.

To Do: 
- Add Drag and drop sorting.  
- maybe also allow to upload files
- Add Radiostream selector