### PR TITLE
Removing Hamming Window use from Audio Encoder

### DIFF
--- a/src/utils/encoder.tsx
+++ b/src/utils/encoder.tsx
@@ -39,21 +39,10 @@ export function upload(
             const leftChannelData = new Float32Array(upsampledAudioBuffer.getChannelData(0));
             const rightChannelData = new Float32Array(upsampledAudioBuffer.getChannelData(1));
 
-            const applyHammingWindow = (data: Float32Array) => {
-                const window = new Float32Array(data.length);
-                for (let i = 0; i < data.length; i++) {
-                    window[i] = 0.54 - 0.46 * Math.cos((2 * Math.PI * i) / (data.length - 1));
-                }
-                return data.map((value, index) => value * window[index]);
-            };
-
-            const leftChannelDataWindowed = applyHammingWindow(leftChannelData);
-            const rightChannelDataWindowed = applyHammingWindow(rightChannelData);
-
             const interleavedData = new Int16Array(leftChannelData.length + rightChannelData.length);
             for (let i = 0, j = 0; i < leftChannelData.length; i++, j += 2) {
-                interleavedData[j] = Math.max(-32767, Math.min(32767, leftChannelDataWindowed[i] * 32767));
-                interleavedData[j + 1] = Math.max(-32767, Math.min(32767, rightChannelDataWindowed[i] * 32767));
+                interleavedData[j] = Math.max(-32767, Math.min(32767, leftChannelData[i] * 32767));
+                interleavedData[j + 1] = Math.max(-32767, Math.min(32767, rightChannelData[i] * 32767));
             }
 
             // Debug and save PCM data if needed


### PR DESCRIPTION
This seems to fix Issue #101. I may be misunderstanding Hamming Window, but it seems like it should be used for parts of the audio that go above the limit and that you want to bring back to within the limits, but still preserve the effect by smoothing it out. The fact that we were applying this to the whole recording made the start and end of the audio file quiet, but the middle the loudest. I honestly don't think we should be changing the recording in any way. Users can and likely should be doing that through external tools, such as Audacity. It has features such as Normalization, which would likely accomplish what this hamming window was trying to do.