### PR TITLE
fixing some bugs

### DIFF
--- a/src/components/utils/FileBrowser.tsx
+++ b/src/components/utils/FileBrowser.tsx
@@ -705,8 +705,8 @@ export const FileBrowser: React.FC<{
                     const parentNodeId = findNodeIdByFullPath(createDirectoryPath + "/", treeData) || rootTreeNode.id;
                     const newNodeId = `${parentNodeId}.${treeData.length}`; // Generate a unique ID for the new node
                     const nodeExpanded = isNodeExpanded(parentNodeId);
-
-                    if (nodeExpanded) {
+                    const childNodes = findNodesByParentId(parentNodeId, treeData);
+                    if (nodeExpanded || childNodes.length > 0) {
                         const newDir = {
                             id: newNodeId,
                             pId: parentNodeId,

--- a/src/components/utils/FileBrowser.tsx
+++ b/src/components/utils/FileBrowser.tsx
@@ -374,17 +374,17 @@ export const FileBrowser: React.FC<{
 
     const pathFromNodeId = (nodeId: string): string => {
         const node = treeData.filter((entry) => entry.value === nodeId)[0];
-        if (!node || node.pId === "-1") return "";
+        if (node.pId === "-1") return "";
         return pathFromNodeId(treeData.filter((entry) => entry.id === node.pId)[0].id) + "/" + node.title;
     };
 
-    const findNodeIdByFullPath = (fullPath: string, nodes: any[]): string => {
+    const findNodeIdByFullPath = (fullPath: string, nodes: any[]): string | null => {
         for (const node of nodes) {
             if (node.fullPath === fullPath) {
                 return node.id;
             }
         }
-        return rootTreeNode.id;
+        return null;
     };
 
     const findNodesByParentId = (parentId: string, nodes: any[]): string[] => {
@@ -702,7 +702,7 @@ export const FileBrowser: React.FC<{
                     if (text !== "OK") {
                         throw new Error(text);
                     }
-                    const parentNodeId = findNodeIdByFullPath(createDirectoryPath + "/", treeData);
+                    const parentNodeId = findNodeIdByFullPath(createDirectoryPath + "/", treeData) || rootTreeNode.id;
                     const newNodeId = `${parentNodeId}.${treeData.length}`; // Generate a unique ID for the new node
                     const nodeExpanded = isNodeExpanded(parentNodeId);
 

--- a/src/components/utils/FileBrowser.tsx
+++ b/src/components/utils/FileBrowser.tsx
@@ -130,6 +130,7 @@ export const FileBrowser: React.FC<{
 
     const [treeNodeId, setTreeNodeId] = useState<string>(rootTreeNode.id);
     const [treeData, setTreeData] = useState<Omit<DefaultOptionType, "label">[]>([rootTreeNode]);
+    const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
 
     const [isMoveFileModalOpen, setIsMoveFileModalOpen] = useState(false);
 
@@ -373,7 +374,7 @@ export const FileBrowser: React.FC<{
 
     const pathFromNodeId = (nodeId: string): string => {
         const node = treeData.filter((entry) => entry.value === nodeId)[0];
-        if (node.pId === "-1") return "";
+        if (!node || node.pId === "-1") return "";
         return pathFromNodeId(treeData.filter((entry) => entry.id === node.pId)[0].id) + "/" + node.title;
     };
 
@@ -394,6 +395,10 @@ export const FileBrowser: React.FC<{
             }
         }
         return childNodes;
+    };
+
+    const isNodeExpanded = (nodeId: string) => {
+        return expandedKeys.includes(nodeId);
     };
 
     // tap functions
@@ -535,6 +540,8 @@ export const FileBrowser: React.FC<{
                         treeData={treeData}
                         treeNodeLabelProp="fullPath"
                         placeholder={t("fileBrowser.moveFile.destinationPlaceholder")}
+                        treeExpandedKeys={expandedKeys}
+                        onTreeExpand={(keys) => setExpandedKeys(keys)}
                     />
                     <Tooltip title={t("fileBrowser.createDirectory.createDirectory")}>
                         <Button
@@ -697,8 +704,9 @@ export const FileBrowser: React.FC<{
                     }
                     const parentNodeId = findNodeIdByFullPath(createDirectoryPath + "/", treeData);
                     const newNodeId = `${parentNodeId}.${treeData.length}`; // Generate a unique ID for the new node
-                    const childNodes = findNodesByParentId(parentNodeId, treeData);
-                    if (childNodes.length > 0) {
+                    const nodeExpanded = isNodeExpanded(parentNodeId);
+
+                    if (nodeExpanded) {
                         const newDir = {
                             id: newNodeId,
                             pId: parentNodeId,

--- a/src/pages/community/ChangelogPage.tsx
+++ b/src/pages/community/ChangelogPage.tsx
@@ -30,6 +30,7 @@ export const ChangelogPage = () => {
                 "gui: Fixed display bug sourceInfo with unknown content",
                 "gui: Integrated new reload tonies.json api",
                 "gui: Added Moving and renaming of files in library and content",
+                "gui: Fixing security weaknesses",
             ],
             commits: [
                 "https://github.com/toniebox-reverse-engineering/teddycloud/compare/tc_v0.6.0...tc_v0.6.1",

--- a/src/pages/tonies/EncoderPage.tsx
+++ b/src/pages/tonies/EncoderPage.tsx
@@ -264,7 +264,10 @@ export const EncoderPage = () => {
             title: inputValueCreateDirectory,
         };
         try {
-            api.apiPostTeddyCloudRaw(`/api/dirCreate?special=library`, path + "/" + inputValueCreateDirectory)
+            api.apiPostTeddyCloudRaw(
+                `/api/dirCreate?special=library`,
+                path + "/" + encodeURIComponent(inputValueCreateDirectory),
+            )
                 .then((response) => {
                     return response.text();
                 })


### PR DESCRIPTION
improved handling of creating new folders in context of tree select component for moving files. Not 100% perfect, but with the best effort-use-ratio ;)

Still at least one downside: When I create a new folder in the move file dialog before expanding its parent folder in the treeselect, the new folder will not be autoselected. I have to expand the current folder and then i can choose the newly created one. When I expand the parent folder first and then create the new folder, the new folder is autoselected.

