### PR TITLE
add save button to settings page

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -345,14 +345,16 @@
             "title": "RTNL Log"
         },
         "saved": "Einstellung gespeichert!",
+        "save": "Speichern",
+        "discard": "Verwerfen",
         "title": "Einstellungen",
         "tonieboxes": "Tonieboxen",
         "toniesJsonReload": "Lade Tonies.json",
         "toniesJsonReloadFailed": "Tonies(.custom).json neu laden fehlgeschlagen!",
         "toniesJsonReloadInProgress": "Lade Tonies(.custom).json...",
         "toniesJsonReloadSuccessful": "Tonies(.custom).json erfolgreich neu geladen!",
-        "warning": "Achtung! Speicherbutton + Settings level",
-        "warningHint": "Texteingaben müssen derzeit explizit gespeichert werden, bis eine bessere Lösung implementiert ist. Klicke dazu auf das Speichersymbol am Ende des Feldes. Falls du Einstellungen vermisst, erhöhe das 'Settings level'."
+        "warning": "Achtung! Settings level",
+        "warningHint": "Falls du Einstellungen vermisst, erhöhe das 'Settings level'."
     },
     "tonieArticleSearch": {
         "failedToFetchSearchResults": "Suchergebnisse konnten nicht abgerufen werden: "

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -344,14 +344,16 @@
             "title": "RTNL Log"
         },
         "saved": "Setting saved!",
+        "save": "Save",
+        "discard": "Discard changes",
         "title": "Settings",
         "tonieboxes": "tonieboxes",
         "toniesJsonReload": "Reload Tonies.json",
         "toniesJsonReloadFailed": "Failed to reload Tonies(.custom).json!",
         "toniesJsonReloadInProgress": "Loading Tonies(.custom).json...",
         "toniesJsonReloadSuccessful": "Tonies(.custom).json reloaded successfully!",
-        "warning": "Attention! Save button + Settings level",
-        "warningHint": "Text inputs currently have to be saved explicitly until a better solution is implemented. To do this, click on the save symbol at the end of the field. If you are missing settings, increase the 'Settings level'."
+        "warning": "Attention!  Settings level",
+        "warningHint": "If you are missing settings, increase the 'Settings level'."
     },
     "tonieArticleSearch": {
         "failedToFetchSearchResults": "Failed to fetch search results: "

--- a/public/translations/fr.json
+++ b/public/translations/fr.json
@@ -344,14 +344,16 @@
             "title": "Journal RTNL"
         },
         "saved": "Paramètre enregistré !",
+        "save": "Enregister",
+        "discard": "Ignorer les modifications",
         "title": "Paramètres",
         "tonieboxes": "tonieboxes",
         "toniesJsonReload": "Recharger Tonies.json",
         "toniesJsonReloadFailed": "Échec du rechargement de Tonies(.custom).json!",
         "toniesJsonReloadInProgress": "Chargement de Tonies(.custom).json...",
         "toniesJsonReloadSuccessful": "Tonies(.custom).json rechargé avec succès!",
-        "warning": "Attention ! Bouton de sauvegarde + Niveau des paramètres",
-        "warningHint": "Les entrées de texte doivent actuellement être enregistrées explicitement jusqu'à ce qu'une meilleure solution soit mise en œuvre. Pour ce faire, cliquez sur le symbole de sauvegarde à la fin du champ. Si des paramètres vous manquent, augmentez le 'Niveau des paramètres'."
+        "warning": "Attention ! Niveau des paramètres",
+        "warningHint": "Si des paramètres vous manquent, augmentez le 'Niveau des paramètres'."
     },
     "tonieArticleSearch": {
         "failedToFetchSearchResults": "Échec de la récupération des résultats de recherche : "

--- a/src/data/SettingsDataHandler.ts
+++ b/src/data/SettingsDataHandler.ts
@@ -1,0 +1,146 @@
+import { message } from "antd";
+import { t } from "i18next";
+import { TeddyCloudApi } from "../api/apis/TeddyCloudApi";
+import { defaultAPIConfig } from "../config/defaultApiConfig";
+
+export interface Setting {
+    description: string;
+    iD: string;
+    label: string;
+    overlayed: boolean;
+    shortname: string;
+    type: string;
+    value: boolean | string | number;
+    initialValue?: boolean | string | number;
+    overlayId?: string;
+}
+
+export default class SettingsDataHandler {
+    private static instance: SettingsDataHandler | undefined = undefined;
+    private settings: Setting[] = [];
+    private unsavedChanges: boolean = false;
+    private listeners: (() => void)[] = [];
+    private idListeners: { iD: string; listener: () => {} }[] = [];
+
+    private constructor() {}
+
+    public hasUnchangedChanges() {
+        return this.unsavedChanges;
+    }
+
+    public static getInstance() {
+        if (SettingsDataHandler.instance === undefined) {
+            SettingsDataHandler.instance = new SettingsDataHandler();
+        }
+        return SettingsDataHandler.instance;
+    }
+
+    //initialize settings from server
+    public initializeSettings(data: Setting[]) {
+        data.forEach((setting) => {
+            setting.initialValue = setting.value;
+        });
+        this.settings = data;
+    }
+
+    public addListener(listener: () => void) {
+        if (!this.listeners.find((currentListener) => currentListener === listener)) {
+            this.listeners.push(listener);
+        }
+    }
+
+    removeListener(listener: () => void) {
+        this.listeners.filter((currentListener) => currentListener !== listener);
+    }
+
+    public addIdListener(listener: () => void, iD: string) {
+        if (!this.idListeners.find((element) => element.listener === listener)) {
+            this.listeners.push(listener);
+        }
+    }
+
+    removeIdListener(listener: () => void) {
+        this.idListeners.filter((element) => element.listener !== listener);
+    }
+
+    private callAllListeners() {
+        this.listeners.forEach((listener) => listener());
+    }
+
+    //TODO: save changes to server (batched)
+    public saveAll() {
+        this.settings.forEach(async (setting) => {
+            if (setting.initialValue !== setting.value) {
+                await this.saveSingleSetting(setting);
+            }
+        });
+        this.settings.forEach((setting) => (setting.initialValue = setting.value));
+        this.unsavedChanges = false;
+        this.callAllListeners();
+    }
+
+    private saveSingleSetting(setting: Setting) {
+        const api = new TeddyCloudApi(defaultAPIConfig());
+        const triggerWriteConfig = async () => {
+            await api.apiTriggerWriteConfigGet();
+        };
+
+        try {
+            return api
+                .apiPostTeddyCloudSetting(setting.iD, setting.value, setting.overlayId)
+                .then(() => {
+                    triggerWriteConfig();
+                    message.success(t("settings.saved") + ": " + setting.label);
+                })
+                .catch((e) => {
+                    message.error("Error while sending data to file: " + setting.label);
+                });
+        } catch (e) {
+            message.error("Error while sending data to server: " + setting.label);
+            return Promise<null>;
+        }
+
+        //TODO: what did this do in InputField? helpers.setValue(field.value || "");
+    }
+
+    public resetAll() {
+        this.settings.forEach((setting) => (setting.value = setting.initialValue ?? ""));
+        this.unsavedChanges = false;
+        this.callAllListeners();
+        this.idListeners.forEach((element) => element.listener());
+    }
+
+    public getSetting(iD: string) {
+        return this.settings.find((setting) => setting.iD === iD);
+    }
+
+    public changeSetting(iD: string, newValue: boolean | string | number) {
+        const settingToChange = this.settings.find((setting) => setting.iD === iD);
+        if (settingToChange) {
+            if (typeof settingToChange.initialValue === typeof newValue) {
+                settingToChange.value = newValue;
+                if (settingToChange.initialValue === settingToChange.value) {
+                    //check all settings and if the save button should still be shown
+                    this.unsavedChanges = false;
+                    this.settings.forEach((setting) => {
+                        if (setting.initialValue !== setting.value) {
+                            this.unsavedChanges = true;
+                        }
+                    });
+                } else {
+                    this.unsavedChanges = true;
+                }
+                this.idListeners
+                    .filter((element) => element.iD === iD)
+                    .forEach((element) => {
+                        element.listener();
+                    });
+                this.callAllListeners();
+            } else {
+                console.warn("The type of newValue and initialValue for '" + iD + "' do not match! Omitting.");
+            }
+        } else {
+            console.warn("Unknown setting '" + iD + "' to be changed. Omitting.");
+        }
+    }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,21 @@ code {
     border-top: 8px solid orange;
 }
 
+.sticky-footer-panel div {
+    position: fixed;
+    bottom: 2px;
+    right: 15px;
+    padding-right: 12px;
+    padding-left: 12px;
+    padding-bottom: 8px;
+    margin-bottom: 0px;
+    z-index: 11;
+}
+
+.sticky-footer-panel div div {
+    padding: 0 !important;
+}
+
 .sticky-footer .ant-modal-footer {
     position: sticky;
     bottom: 0;
@@ -52,11 +67,11 @@ code {
     padding: 20px 24px 0;
 }
 
-.ant-form-item .ant-form-item-label>label.ant-form-item-required:not(.ant-form-item-required-mark-optional)::before {
+.ant-form-item .ant-form-item-label > label.ant-form-item-required:not(.ant-form-item-required-mark-optional)::before {
     display: none;
 }
 
-.ant-form-item .ant-form-item-label>label.ant-form-item-required:not(.ant-form-item-required-mark-optional)::after {
+.ant-form-item .ant-form-item-label > label.ant-form-item-required:not(.ant-form-item-required-mark-optional)::after {
     color: #ff4d4f !important;
     display: inline-block;
     margin-inline-end: 4px;
@@ -101,7 +116,7 @@ code {
 }
 
 .ant-steps .ant-steps-item-process.ant-steps-item-in-progress .ant-steps-item-icon::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
@@ -164,8 +179,8 @@ code {
 /* workaround to set same card height within a row,
  * solution based on proposed solution in https://github.com/ant-design/ant-design/issues/40786
  * --> https://stackblitz.com/edit/react-wf9wmw-2i6mck?file=index.css,demo.tsx */
-.ant-list .ant-row>div,
-.ant-list .ant-row>div,
+.ant-list .ant-row > div,
+.ant-list .ant-row > div,
 .ant-list .ant-row .ant-col:first-child {
     display: flex;
 }

--- a/src/pages/settings/SettingsButtons.tsx
+++ b/src/pages/settings/SettingsButtons.tsx
@@ -1,0 +1,34 @@
+import { Button } from "antd";
+import { t } from "i18next";
+import { FunctionComponent, useState } from "react";
+import SettingsDataHandler from "../../data/SettingsDataHandler";
+
+interface SettingsButtonProps {}
+
+export const SettingsButton: FunctionComponent<SettingsButtonProps> = () => {
+    const [reloadCount, setReloadCount] = useState(0);
+
+    const listener = () => {
+        setReloadCount(reloadCount + 1);
+    };
+    SettingsDataHandler.getInstance().addListener(listener);
+    const isDisabled = !SettingsDataHandler.getInstance().hasUnchangedChanges();
+    return (
+        <div
+            style={{
+                display: "flex",
+                gap: 8,
+                justifyContent: "flex-end",
+            }}
+        >
+            <Button disabled={isDisabled} onClick={() => SettingsDataHandler.getInstance().resetAll()}>
+                {t("settings.discard")}
+            </Button>
+            <Button disabled={isDisabled} type="primary" onClick={() => SettingsDataHandler.getInstance().saveAll()}>
+                {t("settings.save")}
+            </Button>
+        </div>
+    );
+};
+
+export default SettingsButton;

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -1,19 +1,20 @@
-import React from "react";
-import { Form, Alert, Divider, Radio, message } from "antd";
-import { Link } from "react-router-dom"; // Import Link from React Router
+import { Alert, Divider, Form, Radio, message } from "antd";
+import { Formik } from "formik";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom"; // Import Link from React Router
+import { OptionsList, TeddyCloudApi } from "../../api";
+import { SettingsSubNav } from "../../components/settings/SettingsSubNav";
 import BreadcrumbWrapper, {
     HiddenDesktop,
     StyledContent,
     StyledLayout,
     StyledSider,
 } from "../../components/StyledComponents";
-import { SettingsSubNav } from "../../components/settings/SettingsSubNav";
-import { OptionsList, TeddyCloudApi } from "../../api";
 import { defaultAPIConfig } from "../../config/defaultApiConfig";
-import { useEffect, useState } from "react";
-import OptionItem from "../../components/utils/OptionItem";
-import { Formik } from "formik";
+import SettingsDataHandler from "../../data/SettingsDataHandler";
+import { SettingsOptionItem } from "./fields/SettingsOptionItem";
+import SettingsButton from "./SettingsButtons";
 
 const api = new TeddyCloudApi(defaultAPIConfig());
 
@@ -60,6 +61,7 @@ export const SettingsPage = () => {
             const optionsRequest = (await api.apiGetIndexGet("")) as OptionsList;
             if (optionsRequest?.options?.length && optionsRequest?.options?.length > 0) {
                 setOptions(optionsRequest);
+                SettingsDataHandler.getInstance().initializeSettings(optionsRequest.options);
             }
             setLoading(false);
         };
@@ -84,6 +86,14 @@ export const SettingsPage = () => {
             message.error("Error while sending data to server.");
         }
     };
+
+    const stickyFooter = (
+        <div id="testfooter" className="sticky-footer-panel">
+            <div>
+                <SettingsButton></SettingsButton>
+            </div>
+        </div>
+    );
 
     return (
         <>
@@ -164,7 +174,7 @@ export const SettingsPage = () => {
                                             }
                                             return null;
                                         })}
-                                        <OptionItem option={option} noOverlay={true} key={option.iD} />
+                                        <SettingsOptionItem iD={option.iD} />
                                     </React.Fragment>
                                 );
                             })}
@@ -187,6 +197,7 @@ export const SettingsPage = () => {
                             Expert
                         </Radio.Button>
                     </Radio.Group>
+                    {stickyFooter}
                 </StyledContent>
             </StyledLayout>
         </>

--- a/src/pages/settings/fields/SettingsInputField.tsx
+++ b/src/pages/settings/fields/SettingsInputField.tsx
@@ -1,0 +1,44 @@
+import { Input } from "antd";
+import FormItem from "antd/es/form/FormItem";
+import { useField } from "formik";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import SettingsDataHandler from "../../../data/SettingsDataHandler";
+
+type InputFieldProps = {
+    name: string;
+    label?: string;
+    description?: string;
+};
+
+export const SettingsInputField = (props: InputFieldProps) => {
+    const { t } = useTranslation();
+    const { name, label, description } = props;
+    const [field, meta] = useField(name!);
+    const [fieldValue, setFieldValue] = useState(SettingsDataHandler.getInstance().getSetting(name)?.value);
+    const idListener = () => setFieldValue(SettingsDataHandler.getInstance().getSetting(name)?.value);
+    SettingsDataHandler.getInstance().addIdListener(idListener, name);
+
+    const hasFeedback = !!(meta.touched && meta.error);
+    const help = meta.touched && meta.error && t(meta.error);
+    const validateStatus = meta.touched && meta.error ? "error" : undefined;
+
+    let value = fieldValue?.toString();
+    return (
+        <FormItem
+            help={hasFeedback ? help : undefined}
+            validateStatus={validateStatus}
+            label={label}
+            tooltip={description}
+        >
+            <Input
+                {...field}
+                value={value}
+                onChange={(changeEventHandler) => {
+                    SettingsDataHandler.getInstance().changeSetting(name, changeEventHandler.target.value);
+                    setFieldValue(SettingsDataHandler.getInstance().getSetting(name)?.value);
+                }}
+            />
+        </FormItem>
+    );
+};

--- a/src/pages/settings/fields/SettingsInputNumberField.tsx
+++ b/src/pages/settings/fields/SettingsInputNumberField.tsx
@@ -1,0 +1,44 @@
+import { InputNumber } from "antd";
+import FormItem from "antd/es/form/FormItem";
+import { useField } from "formik";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import SettingsDataHandler from "../../../data/SettingsDataHandler";
+
+type InputNumberFieldProps = {
+    name: string;
+    label?: string;
+    description?: string;
+};
+
+export const SettingsInputNumberField = (props: InputNumberFieldProps) => {
+    const { t } = useTranslation();
+    const { name, label, description } = props;
+    const [field, meta, helpers] = useField<number | undefined>(name!);
+    const [fieldValue, setFieldValue] = useState(SettingsDataHandler.getInstance().getSetting(name)?.value);
+    const idListener = () => setFieldValue(SettingsDataHandler.getInstance().getSetting(name)?.value);
+    SettingsDataHandler.getInstance().addIdListener(idListener, name);
+
+    const hasFeedback = !!(meta.touched && meta.error);
+    const help = meta.touched && meta.error && t(meta.error);
+    const validateStatus = meta.touched && meta.error ? "error" : undefined;
+
+    return (
+        <FormItem
+            help={hasFeedback ? help : undefined}
+            validateStatus={validateStatus}
+            label={label}
+            tooltip={description}
+        >
+            <InputNumber
+                {...field}
+                value={fieldValue as number}
+                onChange={(value) => {
+                    SettingsDataHandler.getInstance().changeSetting(name, value ?? 0);
+                    setFieldValue(SettingsDataHandler.getInstance().getSetting(name)?.value);
+                }}
+                onBlur={() => helpers.setTouched(true)}
+            />
+        </FormItem>
+    );
+};

--- a/src/pages/settings/fields/SettingsOptionItem.tsx
+++ b/src/pages/settings/fields/SettingsOptionItem.tsx
@@ -1,0 +1,28 @@
+import SettingsDataHandler from "../../../data/SettingsDataHandler";
+import { SettingsInputField } from "./SettingsInputField";
+import { SettingsInputNumberField } from "./SettingsInputNumberField";
+import { SettingsSwitchField } from "./SettingsSwitchField";
+
+interface SettingsOptionItem {
+    iD: string;
+}
+
+export const SettingsOptionItem = (props: SettingsOptionItem) => {
+    const { iD } = props;
+    const option = SettingsDataHandler.getInstance().getSetting(props.iD);
+    if (option !== undefined) {
+        const { type, label, description } = option;
+
+        return (
+            <div key={iD}>
+                {type === "bool" && <SettingsSwitchField name={iD} label={label} description={description} />}
+                {type === "int" && <SettingsInputNumberField name={iD} label={label} description={description} />}
+                {type === "uint" && <SettingsInputNumberField name={iD} label={label} description={description} />}
+                {type === "string" && <SettingsInputField name={iD} label={label} description={description} />}
+            </div>
+        );
+    } else {
+        console.warn("No option found for iD ", iD);
+        return <></>;
+    }
+};

--- a/src/pages/settings/fields/SettingsSwitchField.tsx
+++ b/src/pages/settings/fields/SettingsSwitchField.tsx
@@ -1,0 +1,44 @@
+import { Switch } from "antd";
+import FormItem from "antd/es/form/FormItem";
+import { useField } from "formik";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import SettingsDataHandler from "../../../data/SettingsDataHandler";
+
+type SwitchFieldProps = {
+    name: string;
+    label?: string;
+    description?: string;
+};
+
+export const SettingsSwitchField = (props: SwitchFieldProps) => {
+    const { t } = useTranslation();
+    const { name, label, description } = props;
+    const [field, meta] = useField(name!);
+
+    const [fieldValue, setFieldValue] = useState(SettingsDataHandler.getInstance().getSetting(name)?.value);
+
+    const hasFeedback = !!(meta.touched && meta.error);
+    const help = meta.touched && meta.error && t(meta.error);
+    const validateStatus = meta.touched && meta.error ? "error" : undefined;
+    const idListener = () => setFieldValue(SettingsDataHandler.getInstance().getSetting(name)?.value);
+    SettingsDataHandler.getInstance().addIdListener(idListener, name);
+
+    return (
+        <FormItem
+            help={hasFeedback ? help : undefined}
+            validateStatus={validateStatus}
+            label={label}
+            tooltip={description}
+        >
+            <Switch
+                {...field}
+                checked={fieldValue as boolean}
+                onChange={(value) => {
+                    SettingsDataHandler.getInstance().changeSetting(name, value);
+                    setFieldValue(SettingsDataHandler.getInstance().getSetting(name)?.value);
+                }}
+            />
+        </FormItem>
+    );
+};


### PR DESCRIPTION
I implemented a Singleton to track option changes and make an over all settings save. This applies to all 4 (3) types of OptionItem.
The buttons will only be shown if there are any changes. The position is fixed at the bottom. Feel free to change it. The SettingsButtons will work everywhere you put them.

To have a cleaner code and because I am not completely sure what the overlays do, I made new components for the settings' input fields. My changes could be used or inspirational for the overlays later on. The changes here can already be merged

