### PR TITLE
.dependabot: Add config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
This adds a config for dependabot to update npm dependencies weekly (can be combined later if too noisy) and github actions (currently no github actions in place).