### PR TITLE
harden: add rel="noopener noreferrer" to external target="_blank" links

### DIFF
--- a/src/components/common/footer/StyledFooter.tsx
+++ b/src/components/common/footer/StyledFooter.tsx
@@ -89,7 +89,7 @@ export const StyledFooter = () => {
                                     ? gitHubTCCommitTreeBaseUrl + commitGitSha
                                     : gitHubTCReleasesUrl + "tag/tc_" + versionShort
                             }
-                            target="_blank"
+                            target="_blank" rel="noopener noreferrer"
                         >
                             <HiddenDesktop>
                                 {versionShort} ({commitGitShaShort})
@@ -112,7 +112,7 @@ export const StyledFooter = () => {
                                             ? gitHubTCCommitTreeBaseUrl + latestDevelopSHA
                                             : gitHubTCReleasesUrl + "tag/" + latestReleaseVersion
                                     }
-                                    target="_blank"
+                                    target="_blank" rel="noopener noreferrer"
                                     style={{
                                         display: "inline-flex",
                                         alignItems: "center",
@@ -136,7 +136,7 @@ export const StyledFooter = () => {
                         <b>
                             <Link
                                 to={gitHubSponsoringUrl}
-                                target="_blank"
+                                target="_blank" rel="noopener noreferrer"
                                 style={{ paddingLeft: 8 }}
                             >
                                 {t("footer.sponsor")}

--- a/src/components/community/CommunitySubNav.tsx
+++ b/src/components/community/CommunitySubNav.tsx
@@ -300,7 +300,7 @@ export const CommunitySubNav = () => {
             label: (
                 <Link
                     to={forumUrl}
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                     onClick={() => {
                         setNavOpen(false);
                         setSubNavOpen(false);

--- a/src/components/home/HomeSubNav.tsx
+++ b/src/components/home/HomeSubNav.tsx
@@ -109,7 +109,7 @@ export const HomeSubNav = () => {
             label: (
                 <Link
                     to={gitHubSponsoringUrl}
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                     onClick={() => {
                         setNavOpen(false);
                         setSubNavOpen(false);

--- a/src/components/home/features/Features.tsx
+++ b/src/components/home/features/Features.tsx
@@ -32,7 +32,7 @@ export const Features = () => {
                             ? gitHubTCCommitTreeBaseUrl + commitGitSha
                             : gitHubTCReleasesUrl + "tag/tc_" + versionShort
                     }
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                 >
                     {version.replace(versionShort, "")} {<ExportOutlined />}
                 </Link>

--- a/src/components/home/home/Home.tsx
+++ b/src/components/home/home/Home.tsx
@@ -87,7 +87,7 @@ export const Home = () => {
                                 ? gitHubTCCommitTreeBaseUrl + latestDevelopSHA
                                 : gitHubTCReleasesUrl + "tag/" + latestReleaseVersion
                         }
-                        target="_blank"
+                        target="_blank" rel="noopener noreferrer"
                         style={{
                             display: "inline-flex",
                             alignItems: "center",
@@ -178,7 +178,7 @@ export const Home = () => {
 
             <Paragraph>
                 {t("home.forumIntroPart1")}
-                <Link to={forumUrl} target="_blank">
+                <Link to={forumUrl} target="_blank" rel="noopener noreferrer">
                     {forumUrl} {<ExportOutlined />}
                 </Link>
                 {t("home.forumIntroPart2")}
@@ -200,22 +200,22 @@ export const Home = () => {
                         <Link to="/community/faq">FAQ</Link>
                     </li>
                     <li>
-                        <Link to={gitHubUrl} target="_blank">
+                        <Link to={gitHubUrl} target="_blank" rel="noopener noreferrer">
                             GitHub {<ExportOutlined />}
                         </Link>
                     </li>
                     <li>
-                        <Link to={telegramGroupUrl} target="_blank">
+                        <Link to={telegramGroupUrl} target="_blank" rel="noopener noreferrer">
                             Telegram Chat {<ExportOutlined />}
                         </Link>
                     </li>
                     <li>
-                        <Link to={forumUrl} target="_blank">
+                        <Link to={forumUrl} target="_blank" rel="noopener noreferrer">
                             Discourse Forum {<ExportOutlined />}
                         </Link>
                     </li>
                     <li>
-                        <Link to={wikiUrl} target="_blank">
+                        <Link to={wikiUrl} target="_blank" rel="noopener noreferrer">
                             TeddyCloud Wiki {<ExportOutlined />}
                         </Link>
                     </li>

--- a/src/components/settings/SettingsSubNav.tsx
+++ b/src/components/settings/SettingsSubNav.tsx
@@ -281,7 +281,7 @@ export const SettingsSubNav = () => {
             label: (
                 <Link
                     to={`${extractBaseUrl(new URL(window.location.href))}/legacy.html`}
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                     onClick={() => {
                         setNavOpen(false);
                         setSubNavOpen(false);

--- a/src/components/tonieboxes/boxsetup/OpenBoxGuide.tsx
+++ b/src/components/tonieboxes/boxsetup/OpenBoxGuide.tsx
@@ -120,11 +120,11 @@ export const OpenBoxGuide: React.FC = () => {
         <>
             <Paragraph style={{ fontSize: "small" }}>
                 {t("tonieboxes.boxSetup.openBoxGuide.guideSourcePart1")}{" "}
-                <Link to={t("tonieboxes.boxSetup.openBoxGuide.link1")} target="_blank">
+                <Link to={t("tonieboxes.boxSetup.openBoxGuide.link1")} target="_blank" rel="noopener noreferrer">
                     iFixit[1] {<ExportOutlined />}
                 </Link>{" "}
                 {t("tonieboxes.boxSetup.openBoxGuide.guideSourcePart2")}{" "}
-                <Link to={t("tonieboxes.boxSetup.openBoxGuide.link2")} target="_blank">
+                <Link to={t("tonieboxes.boxSetup.openBoxGuide.link2")} target="_blank" rel="noopener noreferrer">
                     iFixit[2] {<ExportOutlined />}
                 </Link>
                 . {t("tonieboxes.boxSetup.openBoxGuide.guideSourcePart3")}{" "}
@@ -132,7 +132,7 @@ export const OpenBoxGuide: React.FC = () => {
                     Tobias Isakeit {<ExportOutlined />}
                 </Link>{" "}
                 {t("tonieboxes.boxSetup.openBoxGuide.guideSourcePart4")}{" "}
-                <Link to="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">
+                <Link to="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank" rel="noopener noreferrer">
                     {t("tonieboxes.boxSetup.openBoxGuide.guideSourceLicense")} {<ExportOutlined />}
                 </Link>
             </Paragraph>
@@ -143,7 +143,7 @@ export const OpenBoxGuide: React.FC = () => {
 
             <Paragraph>
                 {t("tonieboxes.boxSetup.openBoxGuide.alternativeGuidelineVideo")}{" "}
-                <Link to="https://www.youtube.com/watch?v=Cv9ID4-P6_A" target="_blank">
+                <Link to="https://www.youtube.com/watch?v=Cv9ID4-P6_A" target="_blank" rel="noopener noreferrer">
                     https://www.youtube.com/watch?v=Cv9ID4-P6_A {<ExportOutlined />}
                 </Link>
             </Paragraph>

--- a/src/components/tonieboxes/boxsetup/boxsetupoverview/boxsetup.tsx
+++ b/src/components/tonieboxes/boxsetup/boxsetupoverview/boxsetup.tsx
@@ -116,7 +116,7 @@ export const BoxSetupContent: React.FC = () => {
                             <ul>
                                 {reachableNewbieGuideUrls.map(({ id, url, title }) => (
                                     <li key={id}>
-                                        <a href={url} target="_blank">
+                                        <a href={url} target="_blank" rel="noopener noreferrer">
                                             {title} {<ExportOutlined />}
                                         </a>
                                     </li>
@@ -174,11 +174,11 @@ export const BoxSetupContent: React.FC = () => {
 
             <Paragraph style={{ marginTop: 16 }}>
                 {t("tonieboxes.boxSetup.boxSetupIntro1")}{" "}
-                <Link to={forumUrl} target="_blank">
+                <Link to={forumUrl} target="_blank" rel="noopener noreferrer">
                     {t("tonieboxes.boxSetup.boxSetupIntroForum")}
                 </Link>{" "}
                 {t("tonieboxes.boxSetup.boxSetupIntro2")}{" "}
-                <Link to={telegramGroupUrl} target="_blank">
+                <Link to={telegramGroupUrl} target="_blank" rel="noopener noreferrer">
                     {t("tonieboxes.boxSetup.boxSetupIntroTelegram")}
                 </Link>{" "}
                 {t("tonieboxes.boxSetup.boxSetupIntro3")}

--- a/src/components/tonieboxes/boxsetup/cc3200/elements/InstallCC3200Tool.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3200/elements/InstallCC3200Tool.tsx
@@ -17,7 +17,7 @@ export function installCC3200Tool(): JSX.Element {
             <ul>
                 <li>
                     {t("tonieboxes.boxFlashingCommon.installCC3200Tool.pythonText1")}
-                    <Link to="https://www.python.org/downloads/" target="_blank">
+                    <Link to="https://www.python.org/downloads/" target="_blank" rel="noopener noreferrer">
                         {t("tonieboxes.boxFlashingCommon.installCC3200Tool.pythonTextLink")}{" "}
                         {<ExportOutlined />}
                     </Link>
@@ -27,7 +27,7 @@ export function installCC3200Tool(): JSX.Element {
                     {t("tonieboxes.boxFlashingCommon.installCC3200Tool.gitText1")}
                     <Link
                         to="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git"
-                        target="_blank"
+                        target="_blank" rel="noopener noreferrer"
                     >
                         {t("tonieboxes.boxFlashingCommon.installCC3200Tool.gitTextLink")}{" "}
                         {<ExportOutlined />}
@@ -36,7 +36,7 @@ export function installCC3200Tool(): JSX.Element {
                 </li>
                 <li>
                     {t("tonieboxes.boxFlashingCommon.installCC3200Tool.pipText1")}
-                    <Link to="https://pip.pypa.io/en/stable/installation/" target="_blank">
+                    <Link to="https://pip.pypa.io/en/stable/installation/" target="_blank" rel="noopener noreferrer">
                         {t("tonieboxes.boxFlashingCommon.installCC3200Tool.pipTextLink")}{" "}
                         {<ExportOutlined />}
                     </Link>
@@ -63,7 +63,7 @@ export function installCC3200Tool(): JSX.Element {
             <Paragraph>
                 {t("tonieboxes.boxFlashingCommon.installCC3200Tool.moreInformation")}
             </Paragraph>
-            <Link to="https://github.com/toniebox-reverse-engineering/cc3200tool" target="_blank">
+            <Link to="https://github.com/toniebox-reverse-engineering/cc3200tool" target="_blank" rel="noopener noreferrer">
                 {t("tonieboxes.boxFlashingCommon.installCC3200Tool.link")} {<ExportOutlined />}
             </Link>
         </>

--- a/src/components/tonieboxes/boxsetup/cc3200/steps/Step0Preparations.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3200/steps/Step0Preparations.tsx
@@ -135,7 +135,7 @@ export const Step0Preparations: React.FC<Step0PreparationsProps> = ({ hwTool, on
                     {t("tonieboxes.cc3200BoxFlashing.esp32C3UartGateway.prepareStep2")}{" "}
                     <Link
                         to="https://g3gg0.github.io/ESP32-UART-Gateway/flasher.html"
-                        target="_blank"
+                        target="_blank" rel="noopener noreferrer"
                     >
                         Flashing ESP32-C3 {<ExportOutlined />}
                     </Link>
@@ -235,7 +235,7 @@ export const Step0Preparations: React.FC<Step0PreparationsProps> = ({ hwTool, on
                 {t("tonieboxes.cc3200BoxFlashing.connectToTonieboxConnectDebugPortText1")}
                 <Link
                     to="https://www.tag-connect.com/product/tc2050-idc-nl-10-pin-no-legs-cable-with-ribbon-connector"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                 >
                     TC2050-IDC-NL TagConnector {<ExportOutlined />}
                 </Link>

--- a/src/components/tonieboxes/boxsetup/cc3200/steps/Step1Bootloader.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3200/steps/Step1Bootloader.tsx
@@ -271,7 +271,7 @@ export const Step1Bootloader: React.FC<Step1PreparationsProps> = ({ hwTool }) =>
                 {t("tonieboxes.cc3200BoxFlashing.installingBootloader.downloadText1")}
                 <Link
                     to="https://github.com/toniebox-reverse-engineering/hackiebox_cfw_ng/releases"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                 >
                     {t("tonieboxes.cc3200BoxFlashing.installingBootloader.downloadLink")}{" "}
                     {<ExportOutlined />}
@@ -329,7 +329,7 @@ export const Step1Bootloader: React.FC<Step1PreparationsProps> = ({ hwTool }) =>
                 )}
                 <Link
                     to="https://tonies-wiki.revvox.de/docs/custom-firmware/cc3200/hackieboxng-bl/bootloader/"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                 >
                     {t(
                         "tonieboxes.cc3200BoxFlashing.installingBootloader.installingBootloaderStage2.here",

--- a/src/components/tonieboxes/boxsetup/cc3200/steps/Step3Patches.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3200/steps/Step3Patches.tsx
@@ -24,8 +24,7 @@ export const Step3Patches: React.FC<CC3200Step3PatchesProps> = ({
             <h3>{t("tonieboxes.cc3200BoxFlashing.patches")}</h3>
             <a
                 href="https://tonies-wiki.revvox.de/docs/custom-firmware/cc3200/hackieboxng-bl/ofw-patches/"
-                target="_blank"
-                rel="noreferrer"
+                target="_blank" rel="noopener noreferrer"
             >
                 {t("tonieboxes.cc3200BoxFlashing.patchesMoreInformationLink")} {<ExportOutlined />}
             </a>

--- a/src/components/tonieboxes/boxsetup/cc3200/steps/Step4ApplyingPatches.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3200/steps/Step4ApplyingPatches.tsx
@@ -208,7 +208,7 @@ export const Step4ApplyingPatches: React.FC = () => {
                     )}{" "}
                     <Link
                         to="https://github.com/toniebox-reverse-engineering/hackiebox_cfw_ng/tree/master/sd-bootloader-ng/bootmanager/sd/revvox/boot/patch"
-                        target="_blank"
+                        target="_blank" rel="noopener noreferrer"
                     >
                         {t(
                             "tonieboxes.cc3200BoxFlashing.applyingPatchesSection.technicalDetailsCollapse.patchDirectory",
@@ -218,7 +218,7 @@ export const Step4ApplyingPatches: React.FC = () => {
                     {", "}
                     <Link
                         to="https://tonies-wiki.revvox.de/docs/custom-firmware/cc3200/hackieboxng-bl/ofw-patches/"
-                        target="_blank"
+                        target="_blank" rel="noopener noreferrer"
                     >
                         {t(
                             "tonieboxes.cc3200BoxFlashing.applyingPatchesSection.technicalDetailsCollapse.patchWiki",
@@ -349,7 +349,7 @@ export const Step4ApplyingPatches: React.FC = () => {
                                     )}{" "}
                                     <Link
                                         to="https://github.com/toniebox-reverse-engineering/hackiebox_cfw_ng/blob/master/sd-bootloader-ng/bootmanager/sd/revvox/boot/ngCfg.json"
-                                        target="_blank"
+                                        target="_blank" rel="noopener noreferrer"
                                     >
                                         {t(
                                             "tonieboxes.cc3200BoxFlashing.applyingPatchesSection.technicalDetailsCollapse.section1_link",

--- a/src/components/tonieboxes/boxsetup/cc3235/steps/Step0Preparations.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3235/steps/Step0Preparations.tsx
@@ -36,7 +36,7 @@ export const CC3235Step0Preparations: React.FC<Step0PreparationsProps> = ({
             <h4>{t("tonieboxes.cc3235BoxFlashing.installSerprogFirmware")}</h4>
             <Paragraph>{t("tonieboxes.cc3235BoxFlashing.pico.preparation")}</Paragraph>
             <Paragraph>
-                <Link to="https://github.com/stacksmashing/pico-serprog" target="_blank">
+                <Link to="https://github.com/stacksmashing/pico-serprog" target="_blank" rel="noopener noreferrer">
                     {t("tonieboxes.cc3235BoxFlashing.serprogFirmwareLink")} {<ExportOutlined />}
                 </Link>
             </Paragraph>
@@ -296,7 +296,7 @@ Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub`}
             <h4>{t("tonieboxes.cc3235BoxFlashing.installflashromtool")}</h4>
             {t("tonieboxes.cc3235BoxFlashing.installflashromtoolText")}
             <CodeSnippet language="shell" code={`sudo apt-get install flashrom`} />
-            <Link to="https://www.flashrom.org/" target="_blank">
+            <Link to="https://www.flashrom.org/" target="_blank" rel="noopener noreferrer">
                 {t("tonieboxes.cc3235BoxFlashing.installflashromtoolLink")} {<ExportOutlined />}
             </Link>
 

--- a/src/components/tonieboxes/boxsetup/cc3235/steps/Step1Certificates.tsx
+++ b/src/components/tonieboxes/boxsetup/cc3235/steps/Step1Certificates.tsx
@@ -54,7 +54,7 @@ export const Step1Certificates: React.FC<CC3235Step1CertificatesProps> = ({
                         {t("tonieboxes.cc3235BoxFlashing.flashCAReplacementDescription1")}{" "}
                         <Link
                             to="https://raw.githubusercontent.com/toniebox-reverse-engineering/teddycloud/master/contrib/gencerts.sh"
-                            target="_blank"
+                            target="_blank" rel="noopener noreferrer"
                         >
                             {t("tonieboxes.cc3235BoxFlashing.gencertLinkText")} {<ExportOutlined />}
                         </Link>{" "}

--- a/src/components/tonieboxes/boxsetup/common/elements/DnsForTeddyCloud.tsx
+++ b/src/components/tonieboxes/boxsetup/common/elements/DnsForTeddyCloud.tsx
@@ -52,7 +52,7 @@ uci commit dhcp
                     <ul style={{ marginBottom: 0 }}>
                         <li>
                             {t("tonieboxes.boxFlashingCommon.adguard.moreInformation")}{" "}
-                            <Link to="https://adguard.com/" target="_blank">
+                            <Link to="https://adguard.com/" target="_blank" rel="noopener noreferrer">
                                 https://adguard.com/ {<ExportOutlined />}
                             </Link>
                         </li>

--- a/src/components/tonieboxes/boxsetup/common/modals/AvailableBoxesModal.tsx
+++ b/src/components/tonieboxes/boxsetup/common/modals/AvailableBoxesModal.tsx
@@ -140,7 +140,7 @@ const AvailableBoxesModal: React.FC<AvailableBoxesModalProps> = ({
                 </Paragraph>
                 <Link
                     to="https://tonies-wiki.revvox.de/docs/tools/teddycloud/setup/test-troubleshooting/"
-                    target="_blank"
+                    target="_blank" rel="noopener noreferrer"
                 >
                     {t("tonieboxes.availableBoxModal.troubleShooting")}
                 </Link>

--- a/src/components/tonieboxes/boxsetup/esp32/flashing/steps/Step0Preparations.tsx
+++ b/src/components/tonieboxes/boxsetup/esp32/flashing/steps/Step0Preparations.tsx
@@ -100,7 +100,7 @@ export const Step0Preparations: React.FC<Step0Props> = ({
                                     <ul>
                                         {reachableBackUpUrls.map(({ id, url, title }) => (
                                             <li key={id}>
-                                                <a href={url} target="_blank">
+                                                <a href={url} target="_blank" rel="noopener noreferrer">
                                                     {title} {<ExportOutlined />}
                                                 </a>
                                             </li>

--- a/src/components/tonieboxes/boxsetup/esp32/legacy/steps/Step0Preparations.tsx
+++ b/src/components/tonieboxes/boxsetup/esp32/legacy/steps/Step0Preparations.tsx
@@ -44,7 +44,7 @@ export const Step0Preparations: React.FC = () => {
             <h4>{t("tonieboxes.esp32BoxFlashing.legacy.installESPTool")}</h4>
             <Paragraph>{t("tonieboxes.esp32BoxFlashing.legacy.installESPToolText")}</Paragraph>
             <Paragraph>
-                <Link to="https://github.com/espressif/esptool" target="_blank">
+                <Link to="https://github.com/espressif/esptool" target="_blank" rel="noopener noreferrer">
                     {t("tonieboxes.esp32BoxFlashing.legacy.installESPToolLink")}{" "}
                     {<ExportOutlined />}
                 </Link>

--- a/src/components/tonieboxes/boxsetup/identifyboxversion/IdentifyBoxVersionContent.tsx
+++ b/src/components/tonieboxes/boxsetup/identifyboxversion/IdentifyBoxVersionContent.tsx
@@ -199,7 +199,7 @@ const MacIdentifyForm: React.FC<MacIdentifyFormProps> = ({
             </Button>
             <Paragraph style={{ fontSize: "small", marginTop: 16 }}>
                 {t("tonieboxes.boxSetup.identifyVersion.macvendors")}{" "}
-                <Link to="https://macvendors.com/" target="_blank">
+                <Link to="https://macvendors.com/" target="_blank" rel="noopener noreferrer">
                     {t("tonieboxes.boxSetup.identifyVersion.macvendorsLink")} {<ExportOutlined />}
                 </Link>
             </Paragraph>

--- a/src/components/tonieboxes/tonieboxcard/TonieboxCard.tsx
+++ b/src/components/tonieboxes/tonieboxcard/TonieboxCard.tsx
@@ -697,7 +697,7 @@ export const TonieboxCard: React.FC<{
                                 key="box-mac-cfw-link"
                                 title={t("tonieboxes.linkToBoxCFW")}
                             >
-                                <Link to={"http://" + lastIp} target="_blank">
+                                <Link to={"http://" + lastIp} target="_blank" rel="noopener noreferrer">
                                     {getTonieboxIdFormatted()} <LinkOutlined />
                                 </Link>
                             </Tooltip>

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -39,7 +39,7 @@ export const CommunityPage = () => {
                         <Paragraph>{t("community.community.getInvolvedText2")}</Paragraph>
                         <ul>
                             <li>
-                                <Link to={gitHubUrl} target="_blank">
+                                <Link to={gitHubUrl} target="_blank" rel="noopener noreferrer">
                                     GitHub {<ExportOutlined />}
                                 </Link>
                                 <ul>
@@ -47,7 +47,7 @@ export const CommunityPage = () => {
                                 </ul>
                             </li>
                             <li>
-                                <Link to={telegramGroupUrl} target="_blank">
+                                <Link to={telegramGroupUrl} target="_blank" rel="noopener noreferrer">
                                     Telegram Chat {<ExportOutlined />}
                                 </Link>
                                 <ul>
@@ -55,7 +55,7 @@ export const CommunityPage = () => {
                                 </ul>
                             </li>
                             <li>
-                                <Link to={forumUrl} target="_blank">
+                                <Link to={forumUrl} target="_blank" rel="noopener noreferrer">
                                     Discourse Forum {<ExportOutlined />}
                                 </Link>
                                 <ul>
@@ -63,7 +63,7 @@ export const CommunityPage = () => {
                                 </ul>
                             </li>
                             <li>
-                                <Link to={wikiUrl} target="_blank">
+                                <Link to={wikiUrl} target="_blank" rel="noopener noreferrer">
                                     TeddyCloud Wiki {<ExportOutlined />}
                                 </Link>
                                 <ul>

--- a/src/pages/community/ContributorsPage.tsx
+++ b/src/pages/community/ContributorsPage.tsx
@@ -43,20 +43,20 @@ export const ContributorsPage = () => {
                         <Paragraph>
                             <h3>teddycloud</h3>
                             <div>{t("community.contributors.teddyCloud")}</div>
-                            <Link to={gitHubTCContributorsUrl} target="_blank">
+                            <Link to={gitHubTCContributorsUrl} target="_blank" rel="noopener noreferrer">
                                 {gitHubTCContributorsUrl} {<ExportOutlined />}
                             </Link>
                         </Paragraph>
                         <Paragraph>
                             <h3>teddycloud_web</h3>
                             <div>{t("community.contributors.teddyCloudWeb")}</div>
-                            <Link to={gitHubTCwebContributorsUrl} target="_blank">
+                            <Link to={gitHubTCwebContributorsUrl} target="_blank" rel="noopener noreferrer">
                                 {gitHubTCwebContributorsUrl} {<ExportOutlined />}
                             </Link>
                         </Paragraph>
                         <Paragraph>
                             {t("community.contributors.others")}{" "}
-                            <Link to={gitHubRepositoriesUrl} target="_blank">
+                            <Link to={gitHubRepositoriesUrl} target="_blank" rel="noopener noreferrer">
                                 {gitHubRepositoriesUrl} {<ExportOutlined />}
                             </Link>
                         </Paragraph>
@@ -76,7 +76,7 @@ export const ContributorsPage = () => {
                     <Paragraph>
                         <h3>{t("community.contributors.supportTeam")}</h3>
                         <Paragraph>{t("community.contributors.supportTeamText")}</Paragraph>
-                        <Link to={gitHubSponsoringUrl} target="_blank">
+                        <Link to={gitHubSponsoringUrl} target="_blank" rel="noopener noreferrer">
                             {t("community.contributors.supportTeamLink")} {<ExportOutlined />}
                         </Link>
                     </Paragraph>


### PR DESCRIPTION
Fixes #308

### What

Adds `rel="noopener noreferrer"` to every external `target="_blank"` link that lacked a `rel` — a consistent, mechanical sweep across ~23 files (49 lines).

### Why

Opening a link in a new tab without `rel="noopener"` exposes `window.opener` to the opened page (reverse-tabnabbing) and leaks the referrer. Current browsers imply `noopener` for `target="_blank"`, so this is defense-in-depth/hygiene, but it's best practice and matters most for the one link constructed from server-provided data (`TonieboxCard` box IP).

### Notes / scope

- No behavioral change; attribute-only.
- The mixed-content `http://<boxIp>` fetch in `TonieboxCard` is **not** touched — the box's CFW endpoint is HTTP-only, so that's inherent and out of scope here.
- Verified with `npm run build` (`tsc && vite build`) — passes.

Targeted at `develop`.