### PR TITLE
fix(teddystudio): dark-theme color + mobile sizing in bulk-add modal

### DIFF
--- a/src/components/tonies/teddystudio/input/BulkAddToniesModal.tsx
+++ b/src/components/tonies/teddystudio/input/BulkAddToniesModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Input, Modal, Transfer } from "antd";
+import { Input, Modal, Transfer, theme, Grid } from "antd";
 import type { TransferProps } from "antd";
 import { useTranslation } from "react-i18next";
 
@@ -66,6 +66,8 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
     onConfirm,
 }) => {
     const { t } = useTranslation();
+    const { token } = theme.useToken();
+    const screens = Grid.useBreakpoint();
 
     const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
     const [targetKeys, setTargetKeys] = useState<string[]>([]);
@@ -270,6 +272,13 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
         onClose();
     };
 
+    // Responsive sizing: keep the modal within the viewport on phones and shrink
+    // the two Transfer panes so they fit side-by-side instead of overflowing.
+    // `screens.md` is antd's 768px breakpoint (the repo's standard mobile check).
+    const isMobile = !screens.md;
+    const modalWidth = Math.min(window.innerWidth - 32, 900);
+    const sectionWidth = isMobile ? Math.max(Math.floor((modalWidth - 90) / 2), 120) : 400;
+
     return (
         <Modal
             open={open}
@@ -282,7 +291,7 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
             })}
             okButtonProps={{ disabled: targetKeys.length === 0 }}
             cancelText={t("tonies.teddystudio.cancel")}
-            width={900}
+            width={modalWidth}
             destroyOnHidden
         >
             <Input.Search
@@ -297,7 +306,7 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
                     style={{
                         textAlign: "center",
                         padding: "48px 16px",
-                        color: "rgba(0, 0, 0, 0.45)",
+                        color: token.colorTextDescription,
                     }}
                 >
                     {t("tonies.teddystudio.bulkAdd.modal.searchHint")}
@@ -322,7 +331,7 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
                             : t("tonies.teddystudio.bulkAdd.modal.notFound"),
                     }}
                     render={renderItem}
-                    styles={{ section: { width: 400, height: 480 } }}
+                    styles={{ section: { width: sectionWidth, height: 480 } }}
                     disabled={loading}
                 />
             )}


### PR DESCRIPTION
Fixes #305

### Issues

From the screenshots in #305, the bulk-add tonies modal had two problems:

1. **Dark theme:** the "type to search" hint used a hardcoded `color: "rgba(0, 0, 0, 0.45)"`, which is almost invisible on the dark theme.
2. **Mobile:** the modal was a fixed `width={900}` containing two fixed `400px` `Transfer` panes (~800px of content), so it overflowed phone viewports.

### Fix (one file: `BulkAddToniesModal.tsx`)

- Use antd's `token.colorTextDescription` (via `theme.useToken()`) for the hint color, matching the pattern already used in `teddystudio/grid/LabelGrid.tsx`.
- Size the modal responsively: `width={Math.min(window.innerWidth - 32, 900)}` (unchanged 900 on desktop), and shrink the `Transfer` section width on small screens (`window.innerWidth <= 768`, the repo's existing breakpoint) so the two panes fit inside the modal.

### Notes / scope

- antd's `Transfer` lays its two panes out side-by-side and doesn't stack them vertically natively, so on very narrow phones the panes are necessarily compact — but they now stay **inside** the viewport instead of overflowing. A full vertical-stack layout would be a larger change; this resolves the reported overflow + dark-theme visibility.
- Verified with `npm run build` (`tsc && vite build`) — passes.

Targeted at `develop`.