### PR TITLE
TeddyStudio: mobile-friendly bulk-add tonies modal (touch list on <768px)

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -1810,7 +1810,6 @@
             "no": "No",
             "pic": "Url zum Bild",
             "release": "Release",
-            "remove": "entfernen",
             "save": "Speichern",
             "series": "Serie",
             "seriesHint": "Die Serie wird als Titel der Toniecard angezeigt",
@@ -2213,7 +2212,6 @@
             "exportToJson": "Als JSON exportieren",
             "hideSelectedTags": "Tags ausblenden",
             "select": "Auswählen",
-            "selectAll": "Alle auswählen",
             "selectButtonTooltip": "Auswahlmodus aktivieren",
             "selected": "Tags/Tonies ausgewählt",
             "setLive": "Live aktivieren",
@@ -2285,6 +2283,10 @@
                     "searchHint": "Bitte mindestens 2 Zeichen eingeben, um tonies.json zu durchsuchen.",
                     "searchPlaceholder": "Suchen",
                     "searchPrompt": "tonies.json durchsuchen…",
+                    "selectedCount": "{{count}} zum Hinzufügen vorgemerkt",
+                    "selectAll": "Alle auswählen",
+                    "clearSelection": "Alle entfernen",
+                    "resultsTruncated": "Erste {{shown}} von {{total}} werden angezeigt — weiter tippen zum Eingrenzen",
                     "title": "Mehrere Tonies zum Druckbogen hinzufügen"
                 }
             },

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -1810,7 +1810,6 @@
             "no": "No",
             "pic": "Url to picture",
             "release": "Release",
-            "remove": "remove",
             "save": "Save",
             "series": "Series",
             "seriesHint": "Will be displayed as the title of the Toniecard",
@@ -2213,7 +2212,6 @@
             "exportToJson": "Export to JSON",
             "hideSelectedTags": "Hide tags",
             "select": "Select",
-            "selectAll": "Select all",
             "selectButtonTooltip": "Enable selection mode",
             "selected": "Tags/Tonies selected",
             "setLive": "Enable live",
@@ -2285,6 +2283,10 @@
                     "searchHint": "Type at least 2 characters to search tonies.json.",
                     "searchPlaceholder": "Search",
                     "searchPrompt": "Search tonies.json…",
+                    "selectedCount": "{{count}} queued to add",
+                    "selectAll": "Select all",
+                    "clearSelection": "Clear all",
+                    "resultsTruncated": "Showing first {{shown}} of {{total}} — keep typing to narrow",
                     "title": "Bulk add tonies to print sheet"
                 }
             },

--- a/public/translations/es.json
+++ b/public/translations/es.json
@@ -1810,7 +1810,6 @@
             "no": "No",
             "pic": "URL de la imagen",
             "release": "Lanzamiento",
-            "remove": "eliminar",
             "save": "Guardar",
             "series": "Serie",
             "seriesHint": "Se mostrará como el título de la tarjeta de Tonie",
@@ -2213,7 +2212,6 @@
             "exportToJson": "Exportar a JSON",
             "hideSelectedTags": "Ocultar tags",
             "select": "Seleccionar",
-            "selectAll": "Seleccionar todo",
             "selectButtonTooltip": "Activar modo de selección",
             "selected": "Tags/Tonies seleccionados",
             "setLive": "Activar live",
@@ -2285,6 +2283,10 @@
                     "searchHint": "Escribe al menos 2 caracteres para buscar en tonies.json.",
                     "searchPlaceholder": "Buscar",
                     "searchPrompt": "Buscar en tonies.json…",
+                    "selectedCount": "{{count}} en cola para añadir",
+                    "selectAll": "Seleccionar todo",
+                    "clearSelection": "Quitar todo",
+                    "resultsTruncated": "Mostrando los primeros {{shown}} de {{total}} — sigue escribiendo para acotar",
                     "title": "Añadir varios tonies a la hoja de impresión"
                 }
             },

--- a/public/translations/fr.json
+++ b/public/translations/fr.json
@@ -1810,7 +1810,6 @@
             "no": "Non",
             "pic": "URL de l'image",
             "release": "Sortie",
-            "remove": "supprimer",
             "save": "Enregistrer",
             "series": "Série",
             "seriesHint": "Sera affiché comme titre de la Toniecard",
@@ -2213,7 +2212,6 @@
             "exportToJson": "Exporter en JSON",
             "hideSelectedTags": "Masquer les tags",
             "select": "Sélectionner",
-            "selectAll": "Tout sélectionner",
             "selectButtonTooltip": "Activer le mode de sélection",
             "selected": "Tags/Tonies sélectionnés",
             "setLive": "Activer live",
@@ -2285,6 +2283,10 @@
                     "searchHint": "Tapez au moins 2 caractères pour rechercher dans tonies.json.",
                     "searchPlaceholder": "Rechercher",
                     "searchPrompt": "Rechercher dans tonies.json…",
+                    "selectedCount": "{{count}} à ajouter",
+                    "selectAll": "Tout sélectionner",
+                    "clearSelection": "Tout retirer",
+                    "resultsTruncated": "Affichage des {{shown}} premiers sur {{total}} — continuez à taper pour affiner",
                     "title": "Ajouter plusieurs tonies à la feuille d'impression"
                 }
             },

--- a/src/components/tonies/teddystudio/input/BulkAddToniesModal.tsx
+++ b/src/components/tonies/teddystudio/input/BulkAddToniesModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Input, Modal, Transfer, theme, Grid } from "antd";
+import { Input, Modal, Transfer, theme, Grid, List, Button, Checkbox } from "antd";
 import type { TransferProps } from "antd";
+import { CheckCircleFilled, PlusOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 
 import { TeddyCloudApi } from "../../../../api";
@@ -11,6 +12,11 @@ const api = new TeddyCloudApi(defaultAPIConfig());
 
 const SEARCH_MIN_CHARS = 2;
 const SEARCH_DEBOUNCE_MS = 300;
+
+// Cap how many matched rows the mobile list mounts at once. The catalog is ~6.4k
+// entries and a broad query (e.g. "benjamin") can still match >1k; antd's <List>
+// is not virtualized, so we render a slice and nudge the user to narrow instead.
+const RESULT_CAP = 200;
 
 // Local debounced-value hook. The repo already ships `useDebouncedCallback`
 // (callback variant) but no value variant; rather than pull in a new dep
@@ -48,6 +54,55 @@ export interface BulkAddToniesModalProps {
     onClose: () => void;
     onConfirm: (datasets: BulkAddDataset[]) => void;
 }
+
+/**
+ * One result/queued row: a 32px cover (or a tokenized placeholder when a tonie
+ * has no picture) plus an ellipsized, tooltipped title. Shared by the desktop
+ * <Transfer> render and the mobile tap-to-toggle list so the two never drift.
+ */
+const RowLabel: React.FC<{ pic?: string; title: string }> = ({ pic, title }) => {
+    const { token } = theme.useToken();
+    return (
+        <span
+            style={{ display: "inline-flex", alignItems: "center", gap: 8, minWidth: 0, flex: 1 }}
+        >
+            {pic ? (
+                <img
+                    src={toImageSrc(pic)}
+                    alt=""
+                    style={{
+                        width: 32,
+                        height: 32,
+                        objectFit: "cover",
+                        borderRadius: 4,
+                        flexShrink: 0,
+                    }}
+                />
+            ) : (
+                <span
+                    style={{
+                        width: 32,
+                        height: 32,
+                        flexShrink: 0,
+                        borderRadius: 4,
+                        background: token.colorFillTertiary,
+                    }}
+                />
+            )}
+            <span
+                style={{
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    color: token.colorText,
+                }}
+                title={title}
+            >
+                {title}
+            </span>
+        </span>
+    );
+};
 
 /**
  * Bulk-add tonies modal.
@@ -216,12 +271,49 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
         return [...dataSource, ...extras];
     }, [dataSource, targetKeys, catalog]);
 
+    // Mobile-only derived data. selectedSet gives O(1) per-row membership (the
+    // basket can be large and the results list long).
+    const selectedSet = useMemo(() => new Set(targetKeys), [targetKeys]);
+
+    // Select-all operates on the full filtered match set (dataSource, pre-cap),
+    // mirroring the desktop Transfer's per-pane "select all". Tri-state: checked
+    // when every match is queued, indeterminate when only some are.
+    const filteredKeys = useMemo(() => dataSource.map((d) => d.key), [dataSource]);
+    const allFilteredSelected =
+        filteredKeys.length > 0 && filteredKeys.every((k) => selectedSet.has(k));
+    const someFilteredSelected = filteredKeys.some((k) => selectedSet.has(k));
+
     const searchTooShort = debouncedSearch.trim().length < SEARCH_MIN_CHARS;
+
+    // Mobile results are sliced to RESULT_CAP (perf — antd <List> isn't virtualized);
+    // isTruncated drives a "keep typing to narrow" footer so a capped list never
+    // looks like the complete result set.
+    const visibleResults = useMemo(() => dataSource.slice(0, RESULT_CAP), [dataSource]);
+    const isTruncated = dataSource.length > RESULT_CAP;
 
     const handleChange: TransferProps["onChange"] = (nextTargetKeys) => {
         // antd 6 returns Key[]; coerce to string[] for our string-keyed catalog.
         setTargetKeys(nextTargetKeys.map((k) => String(k)));
     };
+
+    // Mobile tap-to-toggle: add or remove a key from the queue (idempotent).
+    const toggleKey = (key: string) =>
+        setTargetKeys((prev) =>
+            prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+        );
+
+    // Add or remove every current match (the full filtered set) at once.
+    const toggleSelectAll = () =>
+        setTargetKeys((prev) => {
+            const prevSet = new Set(prev);
+            const allSelected =
+                filteredKeys.length > 0 && filteredKeys.every((k) => prevSet.has(k));
+            if (allSelected) {
+                const drop = new Set(filteredKeys);
+                return prev.filter((k) => !drop.has(k));
+            }
+            return [...prev, ...filteredKeys.filter((k) => !prevSet.has(k))];
+        });
 
     const handleSelectChange: TransferProps["onSelectChange"] = (
         sourceSelected,
@@ -230,36 +322,10 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
         setSelectedKeys([...sourceSelected, ...targetSelected].map((k) => String(k)));
     };
 
-    const renderItem: NonNullable<TransferProps<any>["render"]> = (item: any) => {
-        const label = (
-            <span style={{ display: "inline-flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-                {item.pic && (
-                    <img
-                        src={toImageSrc(item.pic)}
-                        alt=""
-                        style={{
-                            width: 32,
-                            height: 32,
-                            objectFit: "cover",
-                            borderRadius: 4,
-                            flexShrink: 0,
-                        }}
-                    />
-                )}
-                <span
-                    style={{
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                    }}
-                    title={item.title}
-                >
-                    {item.title}
-                </span>
-            </span>
-        );
-        return { label, value: item.title };
-    };
+    const renderItem: NonNullable<TransferProps<any>["render"]> = (item: any) => ({
+        label: <RowLabel pic={item.pic} title={item.title} />,
+        value: item.title,
+    });
 
     const handleOk = () => {
         const keyToRaw = new Map(catalog.map((e) => [e.key, e.raw] as const));
@@ -272,12 +338,17 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
         onClose();
     };
 
-    // Responsive sizing: keep the modal within the viewport on phones and shrink
-    // the two Transfer panes so they fit side-by-side instead of overflowing.
-    // `screens.md` is antd's 768px breakpoint (the repo's standard mobile check).
+    // Responsive sizing. `screens.md` is antd's 768px breakpoint (the repo's
+    // standard mobile check): below it we render a single-column touch UI; at/above
+    // it the desktop <Transfer>. The desktop pane width splits the modal content
+    // across both panes plus the ~64px arrow column, clamped to [240, 400] so the
+    // two panes still fit at the md=768 boundary yet stay 400px wide on large
+    // screens (visually identical to before). Unused on mobile (no Transfer there).
     const isMobile = !screens.md;
     const modalWidth = Math.min(window.innerWidth - 32, 900);
-    const sectionWidth = isMobile ? Math.max(Math.floor((modalWidth - 90) / 2), 120) : 400;
+    const sectionWidth = isMobile
+        ? 0
+        : Math.min(Math.max(Math.floor((modalWidth - 64) / 2), 240), 400);
 
     return (
         <Modal
@@ -301,7 +372,156 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
                 allowClear
                 style={{ marginBottom: 12 }}
             />
-            {searchTooShort && targetKeys.length === 0 ? (
+            {isMobile ? (
+                <div>
+                    {/* Compact actions header: tri-state "Select all" + the queued
+                        count + "Clear all". The selection itself is shown inline on
+                        the list rows below, so there is no separate chip tray. */}
+                    <div
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            gap: 8,
+                            minHeight: 32,
+                            marginBottom: 8,
+                            paddingBottom: 8,
+                            borderBottom: `1px solid ${token.colorBorderSecondary}`,
+                        }}
+                    >
+                        {!searchTooShort && filteredKeys.length > 0 ? (
+                            <Checkbox
+                                checked={allFilteredSelected}
+                                indeterminate={someFilteredSelected && !allFilteredSelected}
+                                onChange={toggleSelectAll}
+                            >
+                                {t("tonies.teddystudio.bulkAdd.modal.selectAll", {
+                                    defaultValue: "Select all",
+                                })}
+                            </Checkbox>
+                        ) : (
+                            <span />
+                        )}
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 12 }}>
+                            <span
+                                aria-live="polite"
+                                aria-atomic="true"
+                                style={{
+                                    fontSize: token.fontSizeSM,
+                                    color: token.colorTextDescription,
+                                }}
+                            >
+                                {t("tonies.teddystudio.bulkAdd.modal.selectedCount", {
+                                    count: targetKeys.length,
+                                    defaultValue: "{{count}} queued to add",
+                                })}
+                            </span>
+                            {targetKeys.length > 0 && (
+                                <Button
+                                    type="link"
+                                    size="small"
+                                    onClick={() => setTargetKeys([])}
+                                    style={{
+                                        paddingInline: 0,
+                                        height: "auto",
+                                        fontSize: token.fontSizeSM,
+                                    }}
+                                >
+                                    {t("tonies.teddystudio.bulkAdd.modal.clearSelection", {
+                                        defaultValue: "Clear all",
+                                    })}
+                                </Button>
+                            )}
+                        </span>
+                    </div>
+
+                    {searchTooShort ? (
+                        <div
+                            style={{
+                                textAlign: "center",
+                                padding: "40px 16px",
+                                color: token.colorTextDescription,
+                            }}
+                        >
+                            {t("tonies.teddystudio.bulkAdd.modal.searchHint")}
+                        </div>
+                    ) : (
+                        <div style={{ maxHeight: "55vh", overflowY: "auto", overflowX: "hidden" }}>
+                            <List
+                                loading={loading}
+                                dataSource={visibleResults}
+                                locale={{
+                                    emptyText: t("tonies.teddystudio.bulkAdd.modal.notFound"),
+                                }}
+                                rowKey="key"
+                                renderItem={(item) => {
+                                    const added = selectedSet.has(item.key);
+                                    return (
+                                        <List.Item
+                                            role="checkbox"
+                                            aria-checked={added}
+                                            aria-label={item.title}
+                                            tabIndex={0}
+                                            onClick={() => toggleKey(item.key)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === "Enter" || e.key === " ") {
+                                                    e.preventDefault();
+                                                    toggleKey(item.key);
+                                                }
+                                            }}
+                                            style={{
+                                                cursor: "pointer",
+                                                paddingInline: 8,
+                                                minHeight: 56,
+                                                gap: 12,
+                                                background: added
+                                                    ? token.controlItemBgActive
+                                                    : "transparent",
+                                            }}
+                                        >
+                                            <RowLabel pic={item.pic} title={item.title} />
+                                            {added ? (
+                                                <CheckCircleFilled
+                                                    style={{
+                                                        color: token.colorPrimary,
+                                                        fontSize: 20,
+                                                        flexShrink: 0,
+                                                    }}
+                                                />
+                                            ) : (
+                                                <PlusOutlined
+                                                    style={{
+                                                        color: token.colorTextSecondary,
+                                                        fontSize: 18,
+                                                        flexShrink: 0,
+                                                    }}
+                                                />
+                                            )}
+                                        </List.Item>
+                                    );
+                                }}
+                            />
+                            {isTruncated && (
+                                <div
+                                    style={{
+                                        textAlign: "center",
+                                        padding: "8px 16px",
+                                        fontSize: token.fontSizeSM,
+                                        color: token.colorTextDescription,
+                                    }}
+                                >
+                                    {t("tonies.teddystudio.bulkAdd.modal.resultsTruncated", {
+                                        shown: RESULT_CAP,
+                                        total: dataSource.length,
+                                        defaultValue:
+                                            "Showing first {{shown}} of {{total}} — keep typing to narrow",
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            ) : searchTooShort && targetKeys.length === 0 ? (
                 <div
                     style={{
                         textAlign: "center",

--- a/src/components/tonies/teddystudio/input/BulkAddToniesModal.tsx
+++ b/src/components/tonies/teddystudio/input/BulkAddToniesModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Input, Modal, Transfer } from "antd";
+import { Input, Modal, Transfer, theme, Grid } from "antd";
 import type { TransferProps } from "antd";
 import { useTranslation } from "react-i18next";
 
@@ -66,6 +66,8 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
     onConfirm,
 }) => {
     const { t } = useTranslation();
+    const { token } = theme.useToken();
+    const screens = Grid.useBreakpoint();
 
     const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
     const [targetKeys, setTargetKeys] = useState<string[]>([]);
@@ -270,6 +272,13 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
         onClose();
     };
 
+    // Responsive sizing: keep the modal within the viewport on phones and shrink
+    // the two Transfer panes so they fit side-by-side instead of overflowing.
+    // `screens.md` is antd's 768px breakpoint (the repo's standard mobile check).
+    const isMobile = !screens.md;
+    const modalWidth = Math.min(window.innerWidth - 32, 900);
+    const sectionWidth = isMobile ? Math.max(Math.floor((modalWidth - 90) / 2), 120) : 400;
+
     return (
         <Modal
             open={open}
@@ -282,7 +291,7 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
             })}
             okButtonProps={{ disabled: targetKeys.length === 0 }}
             cancelText={t("tonies.teddystudio.cancel")}
-            width={900}
+            width={modalWidth}
             destroyOnHidden
         >
             <Input.Search
@@ -297,7 +306,7 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
                     style={{
                         textAlign: "center",
                         padding: "48px 16px",
-                        color: "rgba(0, 0, 0, 0.45)",
+                        color: token.colorTextDescription,
                     }}
                 >
                     {t("tonies.teddystudio.bulkAdd.modal.searchHint")}
@@ -322,7 +331,7 @@ export const BulkAddToniesModal: React.FC<BulkAddToniesModalProps> = ({
                             : t("tonies.teddystudio.bulkAdd.modal.notFound"),
                     }}
                     render={renderItem}
-                    styles={{ section: { width: 400, height: 480 } }}
+                    styles={{ section: { width: sectionWidth, height: 480 } }}
                     disabled={loading}
                 />
             )}


### PR DESCRIPTION
## Summary

Follow-up to #311. On phones the bulk-add modal's antd `<Transfer>` squeezes its two list panes to ~139px each, so tonie titles are unreadable and the dual-list "select-then-arrow" interaction is clumsy on touch (as @henryk86 raised on #311 — _"feel free to do the bigger change"_). This proposes a **mobile-specific layout** for `<768px` while keeping the approved desktop `<Transfer>` unchanged.

> **Stacked on #311** — until that merges, the diff below also includes #311's commits. The **incremental change introduced by this PR** is here: [`fix/bulk-add-modal-darktheme-mobile…feat/bulk-add-mobile-redesign`](https://github.com/aflores-qb/teddycloud_web/compare/fix/bulk-add-modal-darktheme-mobile...feat/bulk-add-mobile-redesign).

## What it looks like

Screenshots are from a real instance (the full ~6.4k-entry `tonies.json`).

### Mobile `<768px` — single-column, tap-to-toggle

| Pick a few | "Select all" | Narrow (320px) |
|:---:|:---:|:---:|
| <img src="https://raw.githubusercontent.com/aflores-qb/teddycloud_web/media/bulk-add-mobile/mobile-375.png" width="240"> | <img src="https://raw.githubusercontent.com/aflores-qb/teddycloud_web/media/bulk-add-mobile/mobile-selectall-375.png" width="240"> | <img src="https://raw.githubusercontent.com/aflores-qb/teddycloud_web/media/bulk-add-mobile/mobile-320.png" width="240"> |

### Tablet / desktop `≥768px` — `<Transfer>` unchanged (and now fits at the 768px boundary)

| Tablet (768px) | Desktop (1280px) |
|:---:|:---:|
| <img src="https://raw.githubusercontent.com/aflores-qb/teddycloud_web/media/bulk-add-mobile/tablet-768.png" width="420"> | <img src="https://raw.githubusercontent.com/aflores-qb/teddycloud_web/media/bulk-add-mobile/desktop-1280.png" width="420"> |

## What changed

- **Mobile (`<768px`)** renders a single full-width, search-gated results list of tap-to-toggle rows (cover + ellipsized title + a filled-check / plus state icon). The whole 56px row toggles — no modifier keys. A compact header carries a **tri-state "Select all"** (parity with the desktop pane's select-all), a live **"{N} queued to add"** count, and **"Clear all"**.
- **Desktop (`≥768px`)** keeps the `<Transfer>` verbatim; its pane width now clamps to `[240, 400]px` so the two panes also fit at the `md`=768px boundary (previously 2×400 could overflow). `targetKeys` selection state is shared across the breakpoint, so it's a progressive-enhancement split, not divergent behaviour.

## Why this shape

A dual-list-box/transfer is a desktop pattern with no good small-screen story (PatternFly documents no responsive support and recommends it only for 20+ items). The replacement is the documented cross-platform "multi-select from a large list" pattern — search + tap-to-toggle rows + running count + a single atomic confirm — i.e. the Gmail label-sheet / Apple Music "Add Music" / NN/g faceted-tray model. Selected state uses **shape + colour** (filled check vs outline plus + an active row band), per Material 3, Apple HIG and WCAG 1.4.1. Touch targets are 56px rows with ≥44/48px controls (Apple 44pt / Material 48dp / WCAG 2.5.5).

## Accessibility

- Result rows are `role="checkbox"` + `aria-checked` and keyboard-operable (Enter/Space toggles).
- The queued count is an `aria-live="polite"` region, so additions/removals are announced.

## Performance

The catalog is ~6.4k entries and a broad query can match >1k rows; antd `<List>` isn't virtualized, so the mobile list mounts at most **200** rows with a "keep typing to narrow" footer.

## i18n

Adds `selectedCount`, `selectAll`, `clearSelection`, `resultsTruncated` for **en / de / es / fr**. `npm run format` (Prettier) has been run.
