### PR TITLE
fix(tap-editor): use lib:// prefix for TAP target filepath

### DIFF
--- a/src/components/tonies/filebrowser/modals/TeddyAudioPlaylistEditorModal.tsx
+++ b/src/components/tonies/filebrowser/modals/TeddyAudioPlaylistEditorModal.tsx
@@ -145,9 +145,9 @@ const TeddyAudioPlaylistEditor: React.FC<TeddyAudioPlaylistEditorProps> = ({
     };
 
     const buildFilepath = (dir?: string, filenameBase?: string) => {
-        const d = normalizeDir(dir);
+        const d = normalizeDir(dir).replace(/^\/+/, "");
         const f = ensureTafExt(filenameBase).replace(/^\/+/, "");
-        return `lib:/${d}${f}`;
+        return `lib://${d}${f}`;
     };
 
     const getCurrentDir = () => directoryTree.getPathFromNodeId(directoryTree.treeNodeId);


### PR DESCRIPTION
### Problem
Creating a Toniebox Audio Playlist (TAP) via the TAP editor at the **library root** produces a target `filepath` with a single slash, e.g. `lib:/Musik.taf`.

teddyCloud's `resolveSpecialPathPrefix()` only recognizes the `lib://` scheme, so `lib:/…` is never resolved. When the box then requests the TAP, generation fails to open the resulting `.taf`/`.taf.tmp` (`File opening failed`, error 302) and playback falls back to a slow path instead of the fast TAF-only remux. Symptom in the field: a TAP tag takes ~40s+ to start instead of playing (near-)instantly.

### Root cause
In `TeddyAudioPlaylistEditorModal.tsx`, `buildFilepath()` returns:
```ts
return `lib:/${d}${f}`;   // single slash
```
`getCurrentDir()` returns `""` at the library root, so the result is `lib:/Name.taf`. In a subdirectory `getCurrentDir()` returns a leading-slash path (e.g. `/Sub`), which by luck produced a correct `lib://Sub/...` — so the bug only surfaces at the library root. Note the file-entry construction (`normalizeSelectedBrowserFiles`) and `stripLibPrefix()` already use the correct `lib://`.

### Fix
Strip leading slashes from the directory part and always use the `lib://` prefix, so both the library root and subdirectories produce a valid path:
```ts
const d = normalizeDir(dir).replace(/^\/+/, "");
const f = ensureTafExt(filenameBase).replace(/^\/+/, "");
return `lib://${d}${f}`;
```

### Result
- root: `lib://Name.taf`
- subdir `/Sub`: `lib://Sub/Name.taf`

Existing `.tap` files written with the old single-slash target still need to be corrected (change `lib:/` to `lib://` in the file), or handled on the backend side.
