### PR TITLE
feat: track listened status for library files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - gui: Fixed bug malformed library post request [https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/171](https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/171)
 - gui: Added noopener noreferrer to external links [https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/308](https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/308)
 - gui: Added tonies.custom.json snippet modal for getting skeleton of tonies.custom.json for all or selected tafs in current folder
+- Added "listened" status tracking for library files, incl. auto-mark on sync (opt-out) [https://github.com/toniebox-reverse-engineering/teddycloud/pull/467](https://github.com/toniebox-reverse-engineering/teddycloud/pull/467)
+- gui: Added "listened" toggle for library files and "assign next episode" action on Tonie cards [https://github.com/toniebox-reverse-engineering/teddycloud_web/pull/317](https://github.com/toniebox-reverse-engineering/teddycloud_web/pull/317)
 
 ### Commits
 

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -446,6 +446,7 @@
         },
         "hidden": "Versteckt",
         "image": "Bild",
+        "markAsListened": "Als gehört markieren",
         "maxSelectedRows": "Du kannst nur maximal {{maxSelectedRows}} Dateien auswählen",
         "maxSelectedRowsWarning": "Zu viele Dateien ausgewählt!",
         "messages": {
@@ -477,7 +478,9 @@
             "renamingFailed": "Umbenennen fehlgeschlagen",
             "renamingFailedDetails": "Umbenennen der Datei \"{{fileSource}}\" in \"{{fileTarget}}\" fehlgeschlagen: ",
             "renamingSuccessful": "Datei erfolgreich umbenannt!",
-            "renamingSuccessfulDetails": "Datei \"{{fileSource}}\" erfolgreich in \"{{fileTarget}}\" umbenannt!"
+            "renamingSuccessfulDetails": "Datei \"{{fileSource}}\" erfolgreich in \"{{fileTarget}}\" umbenannt!",
+            "toggleListenedFailed": "Gehört-Status konnte nicht geändert werden",
+            "toggleListenedFailedDetails": "Gehört-Status für Datei \"{{file}}\" konnte nicht geändert werden: "
         },
         "migrateContentToLib": "TAF-Datei in Library (by/audioId/) migrieren",
         "migrateContentToLibRoot": "TAF-Datei in Library (root) migrieren",
@@ -519,6 +522,7 @@
             }
         },
         "title": "Dateibrowser",
+        "unmarkAsListened": "Als nicht gehört markieren",
         "unusedTafsModal": {
             "actions": "Aktionen",
             "fullPath": "Vollständiger Pfad",
@@ -1828,6 +1832,14 @@
         },
         "alternativeSource": "Der Toniefigur {{originalTonie}} ist der Inhalt {{assignedContent}} zugewiesen!",
         "alternativeSourceUnknown": "Der Toniefigur {{originalTonie}} ist alternativer Inhalt zugewiesen!",
+        "assignNextEpisode": {
+            "action": "Nächste Folge zuweisen",
+            "failedDetails": "\"{{episode}}\" konnte nicht zugewiesen werden: ",
+            "failedMessage": "Zuweisen der nächsten Folge fehlgeschlagen!",
+            "noneLeft": "Keine ungehörten Folgen mehr in diesem Ordner",
+            "successDetails": "\"{{episode}}\" als nächste Folge zugewiesen!",
+            "successMessage": "Nächste Folge zugewiesen!"
+        },
         "cancel": "Abbrechen",
         "closeAudioPlayer": "Player schließen",
         "closeAudioPlayerPopover": "Schließen stoppt die Wiedergabe!",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -446,6 +446,7 @@
         },
         "hidden": "Hidden",
         "image": "Image",
+        "markAsListened": "Mark as listened",
         "maxSelectedRows": "You can only select up to {{maxSelectedRows}} files",
         "maxSelectedRowsWarning": "Too many files selected!",
         "messages": {
@@ -477,7 +478,9 @@
             "renamingFailed": "Renaming failed",
             "renamingFailedDetails": "Renaming of file \"{{fileSource}}\" to \"{{fileTarget}}\" failed: ",
             "renamingSuccessful": "Renamed file successfully!",
-            "renamingSuccessfulDetails": "Renamed file \"{{fileSource}}\" to \"{{fileTarget}}\" successfully!"
+            "renamingSuccessfulDetails": "Renamed file \"{{fileSource}}\" to \"{{fileTarget}}\" successfully!",
+            "toggleListenedFailed": "Could not change listened flag",
+            "toggleListenedFailedDetails": "Could not change listened flag for file \"{{file}}\": "
         },
         "migrateContentToLib": "Migrate TAF to library (by/audioId/)",
         "migrateContentToLibRoot": "Migrate TAF to library (root)",
@@ -519,6 +522,7 @@
             }
         },
         "title": "Filebrowser",
+        "unmarkAsListened": "Mark as not listened",
         "unusedTafsModal": {
             "actions": "Actions",
             "fullPath": "Full path",
@@ -1828,6 +1832,14 @@
         },
         "alternativeSource": "This Tonie {{originalTonie}} is assigned the content {{assignedContent}}!",
         "alternativeSourceUnknown": "This Tonie {{originalTonie}} is assigned alternative content!",
+        "assignNextEpisode": {
+            "action": "Assign next episode",
+            "failedDetails": "Could not assign \"{{episode}}\": ",
+            "failedMessage": "Assigning next episode failed!",
+            "noneLeft": "No unlistened episodes left in this folder",
+            "successDetails": "Assigned \"{{episode}}\" as next episode!",
+            "successMessage": "Next episode assigned!"
+        },
         "cancel": "Cancel",
         "closeAudioPlayer": "Close player",
         "closeAudioPlayerPopover": "Close stops playback!",

--- a/public/translations/es.json
+++ b/public/translations/es.json
@@ -446,6 +446,7 @@
         },
         "hidden": "Oculto",
         "image": "Imagen",
+        "markAsListened": "Marcar como escuchado",
         "maxSelectedRows": "Solo puedes seleccionar hasta {{maxSelectedRows}} archivos",
         "maxSelectedRowsWarning": "¡Demasiados archivos seleccionados!",
         "messages": {
@@ -477,7 +478,9 @@
             "renamingFailed": "Error al renombrar",
             "renamingFailedDetails": "Error al renombrar el archivo \"{{fileSource}}\" a \"{{fileTarget}}\": ",
             "renamingSuccessful": "¡Archivo renombrado con éxito!",
-            "renamingSuccessfulDetails": "Archivo \"{{fileSource}}\" renombrado a \"{{fileTarget}}\" con éxito!"
+            "renamingSuccessfulDetails": "Archivo \"{{fileSource}}\" renombrado a \"{{fileTarget}}\" con éxito!",
+            "toggleListenedFailed": "No se pudo cambiar el estado de escuchado",
+            "toggleListenedFailedDetails": "No se pudo cambiar el estado de escuchado del archivo \"{{file}}\": "
         },
         "migrateContentToLib": "Migrar TAF a la biblioteca (por/audioId/)",
         "migrateContentToLibRoot": "Migrar TAF a la biblioteca (raíz)",
@@ -519,6 +522,7 @@
             }
         },
         "title": "Explorador de archivos",
+        "unmarkAsListened": "Marcar como no escuchado",
         "unusedTafsModal": {
             "actions": "Acciones",
             "fullPath": "Ruta completa",
@@ -1828,6 +1832,14 @@
         },
         "alternativeSource": "Este Tonie {{originalTonie}} tiene asignado el contenido {{assignedContent}}!",
         "alternativeSourceUnknown": "¡Este Tonie {{originalTonie}} tiene asignado contenido alternativo!",
+        "assignNextEpisode": {
+            "action": "Asignar siguiente episodio",
+            "failedDetails": "No se pudo asignar \"{{episode}}\": ",
+            "failedMessage": "¡Error al asignar el siguiente episodio!",
+            "noneLeft": "No quedan episodios sin escuchar en esta carpeta",
+            "successDetails": "¡\"{{episode}}\" asignado como siguiente episodio!",
+            "successMessage": "¡Siguiente episodio asignado!"
+        },
         "cancel": "Cancelar",
         "closeAudioPlayer": "Cerrar reproductor",
         "closeAudioPlayerPopover": "¡Cerrar detiene la reproducción!",

--- a/public/translations/fr.json
+++ b/public/translations/fr.json
@@ -446,6 +446,7 @@
         },
         "hidden": "Caché",
         "image": "Image",
+        "markAsListened": "Marquer comme écouté",
         "maxSelectedRows": "Vous ne pouvez sélectionner que jusqu'à {{maxSelectedRows}} fichiers",
         "maxSelectedRowsWarning": "Trop de fichiers sélectionnés !",
         "messages": {
@@ -477,7 +478,9 @@
             "renamingFailed": "Échec du renommage",
             "renamingFailedDetails": "Échec du renommage du fichier \"{{fileSource}}\" en \"{{fileTarget}}\" : ",
             "renamingSuccessful": "Fichier renommé avec succès!",
-            "renamingSuccessfulDetails": "Fichier \"{{fileSource}}\" renommé en \"{{fileTarget}}\" avec succès!"
+            "renamingSuccessfulDetails": "Fichier \"{{fileSource}}\" renommé en \"{{fileTarget}}\" avec succès!",
+            "toggleListenedFailed": "Impossible de modifier le statut écouté",
+            "toggleListenedFailedDetails": "Impossible de modifier le statut écouté du fichier \"{{file}}\" : "
         },
         "migrateContentToLib": "Migrer TAF vers la bibliothèque (par/audioId/)",
         "migrateContentToLibRoot": "Migrer TAF vers la bibliothèque (racine)",
@@ -519,6 +522,7 @@
             }
         },
         "title": "Navigateur de fichiers",
+        "unmarkAsListened": "Marquer comme non écouté",
         "unusedTafsModal": {
             "actions": "Actions",
             "fullPath": "Chemin complet",
@@ -1828,6 +1832,14 @@
         },
         "alternativeSource": "Cette Tonie {{originalTonie}} est assignée à un contenu {{assignedContent}} !",
         "alternativeSourceUnknown": "Cette Tonie {{originalTonie}} est assignée à un contenu alternatif  !",
+        "assignNextEpisode": {
+            "action": "Assigner l'épisode suivant",
+            "failedDetails": "Impossible d'assigner \"{{episode}}\" : ",
+            "failedMessage": "Échec de l'assignation de l'épisode suivant !",
+            "noneLeft": "Aucun épisode non écouté restant dans ce dossier",
+            "successDetails": "\"{{episode}}\" assigné comme épisode suivant !",
+            "successMessage": "Épisode suivant assigné !"
+        },
         "cancel": "Annuler",
         "closeAudioPlayer": "Fermer le lecteur audio",
         "closeAudioPlayerPopover": "Fermer arrête la lecture!",

--- a/src/api/apis/TeddyCloudApi.ts
+++ b/src/api/apis/TeddyCloudApi.ts
@@ -593,6 +593,35 @@ export class TeddyCloudApi extends runtime.BaseAPI {
     }
 
     /**
+     * @description Set/unset the "listened" flag for an arbitrary library (or other special-root) file
+     *
+     * @param path path of the file, relative to the special root (optional)
+     * @param special special root the path is relative to, e.g. "library" (optional)
+     * @param listened target value of the "listened" flag
+     * @param overlay overlay (optional)
+     * @param initOverrides initOverrides (optional)
+     * @returns
+     */
+    async apiPostFileSetListened(
+        path: string,
+        special: string,
+        listened: boolean,
+        overlay?: String,
+        initOverrides?: RequestInit | runtime.InitOverrideFunction,
+    ): Promise<Response> {
+        const response = await this.apiPostTeddyCloudRaw(
+            `/api/fileSetListened?path=${path}&special=${special}${overlay ? "&overlay=" + overlay : ""}`,
+            "listened=" + listened,
+            undefined,
+            initOverrides,
+        );
+        if (!response.ok) {
+            throw new Error(`Error: ${response.status} ${response.statusText}`);
+        }
+        return response;
+    }
+
+    /**
      * @description Post simple data to endpoint path of TeddyCloud api
      *
      * @param apiPath endpoint path of API

--- a/src/components/tonies/common/hooks/useAssignSourceToTonie.ts
+++ b/src/components/tonies/common/hooks/useAssignSourceToTonie.ts
@@ -1,0 +1,26 @@
+import { TeddyCloudApi } from "../../../../api";
+import { defaultAPIConfig } from "../../../../config/defaultApiConfig";
+import { TonieCardProps } from "../../../../types/tonieTypes";
+
+const api = new TeddyCloudApi(defaultAPIConfig());
+
+/**
+ * Assign a "lib://" or "http(s)://" source path to a Tonie tag, mirroring
+ * useTonieCardSaveFlow.handleSourceSave (source + nocloud + live follow-up).
+ */
+export const useAssignSourceToTonie = () => {
+    const assignSourceToTonie = async (tonieCard: TonieCardProps, path: string, overlay: string) => {
+        await api.apiPostTeddyCloudContentJson(tonieCard.ruid, "source=" + encodeURIComponent(path), overlay);
+
+        if (!tonieCard.nocloud) {
+            await api.apiPostTeddyCloudContentJson(tonieCard.ruid, "nocloud=true", overlay);
+        }
+
+        const shouldBeLive = path.startsWith("http");
+        if (shouldBeLive !== tonieCard.live) {
+            await api.apiPostTeddyCloudContentJson(tonieCard.ruid, "live=" + shouldBeLive, overlay);
+        }
+    };
+
+    return { assignSourceToTonie };
+};

--- a/src/components/tonies/filebrowser/FileBrowser.tsx
+++ b/src/components/tonies/filebrowser/FileBrowser.tsx
@@ -36,6 +36,7 @@ import { createColumns } from "./helper/Columns";
 import { useFileBrowserCore } from "./hooks/useFileBrowserCore";
 import { useFileDownload } from "./hooks/useFileDownload";
 import { useMigrateContent2Lib } from "./hooks/useMigrateContent2Lib";
+import { useToggleListened } from "./hooks/useToggleListened";
 import DeleteFilesModal from "./modals/DeleteFilesModal";
 import EncodeFilesModal from "./modals/EncodeFilesModal";
 import JsonViewerModal from "./modals/JsonViewerModal";
@@ -325,6 +326,13 @@ export const FileBrowser: React.FC<{
         setDownloading,
     });
 
+    const { toggleListened } = useToggleListened({
+        path,
+        special,
+        overlay,
+        setRebuildList,
+    });
+
     // table selection / classes
     const rowClassName = (record: any) => {
         return selectedRowKeys.includes(record.key) ? "highlight-row" : "";
@@ -375,6 +383,7 @@ export const FileBrowser: React.FC<{
         showRenameDialog,
         showMoveDialog,
         showDeleteConfirmDialog,
+        toggleListened,
         buildContentUrl: special === "custom_img" ? buildContentUrl : undefined,
         onImagePreviewClick:
             special === "custom_img"

--- a/src/components/tonies/filebrowser/helper/Columns.tsx
+++ b/src/components/tonies/filebrowser/helper/Columns.tsx
@@ -12,6 +12,7 @@ import {
     NodeExpandOutlined,
     DeleteOutlined,
     LoadingOutlined,
+    CheckCircleOutlined,
 } from "@ant-design/icons";
 
 import { IMAGE_EXTENSIONS } from "../../../../constants/fileTypes";
@@ -76,6 +77,7 @@ export interface CreateColumnsOptions {
     showRenameDialog?: (fileName: string) => void;
     showMoveDialog?: (fileName: string) => void;
     showDeleteConfirmDialog?: (fileName: string, fullPath: string, query: string) => void;
+    toggleListened?: (record: Record) => void;
     buildContentUrl?: (fileName: string, options?: { ogg?: boolean }) => string;
     onImagePreviewClick?: (imageUrl: string) => void;
     onRowSelect?: (record: Record) => void;
@@ -111,6 +113,7 @@ export const createColumns = (options: CreateColumnsOptions): any[] => {
         showRenameDialog,
         showMoveDialog,
         showDeleteConfirmDialog,
+        toggleListened,
         buildContentUrl,
         onImagePreviewClick,
         onRowSelect,
@@ -657,6 +660,28 @@ export const createColumns = (options: CreateColumnsOptions): any[] => {
                 }
 
                 if ((special === "library" || special === "custom_img") && record.name !== "..") {
+                    if (!record.isDir && special === "library" && toggleListened) {
+                        actions.push(
+                            <Tooltip
+                                open={!canHover ? false : undefined}
+                                key={`action-listened-${record.name}`}
+                                title={
+                                    record.listened
+                                        ? t("fileBrowser.unmarkAsListened")
+                                        : t("fileBrowser.markAsListened")
+                                }
+                            >
+                                <CheckCircleOutlined
+                                    onClick={() => toggleListened(record)}
+                                    style={{
+                                        margin: "4px 8px 4px 0",
+                                        padding: 4,
+                                        color: record.listened ? token.colorSuccess : undefined,
+                                    }}
+                                />
+                            </Tooltip>,
+                        );
+                    }
                     if (!record.isDir && showRenameDialog) {
                         actions.push(
                             <Tooltip

--- a/src/components/tonies/filebrowser/hooks/useToggleListened.ts
+++ b/src/components/tonies/filebrowser/hooks/useToggleListened.ts
@@ -1,0 +1,37 @@
+import { useTranslation } from "react-i18next";
+
+import { TeddyCloudApi } from "../../../../api";
+import { defaultAPIConfig } from "../../../../config/defaultApiConfig";
+import { useTeddyCloud } from "../../../../provider/TeddyCloudProvider";
+import { NotificationTypeEnum } from "../../../../types/teddyCloudNotificationTypes";
+import { Record } from "../../../../types/fileBrowserTypes";
+
+const api = new TeddyCloudApi(defaultAPIConfig());
+
+interface UseToggleListenedParams {
+    path: string;
+    special: string;
+    overlay?: string;
+    setRebuildList: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function useToggleListened({ path, special, overlay, setRebuildList }: UseToggleListenedParams) {
+    const { t } = useTranslation();
+    const { addNotification } = useTeddyCloud();
+
+    const toggleListened = async (record: Record) => {
+        try {
+            await api.apiPostFileSetListened(path + "/" + record.name, special, !record.listened, overlay);
+            setRebuildList((prev) => !prev);
+        } catch (error) {
+            addNotification(
+                NotificationTypeEnum.Error,
+                t("fileBrowser.messages.toggleListenedFailed"),
+                t("fileBrowser.messages.toggleListenedFailedDetails", { file: record.name }) + error,
+                t("fileBrowser.title"),
+            );
+        }
+    };
+
+    return { toggleListened };
+}

--- a/src/components/tonies/toniecard/TonieCard.tsx
+++ b/src/components/tonies/toniecard/TonieCard.tsx
@@ -8,6 +8,7 @@ import {
     InfoCircleOutlined,
     PlayCircleOutlined,
     RetweetOutlined,
+    StepForwardOutlined,
     StopOutlined,
 } from "@ant-design/icons";
 
@@ -31,6 +32,7 @@ import { useResolvedModelAudio } from "./hooks/useResolvedModelAudio";
 import { useTooltipInfoByModel } from "./hooks/useTooltipInfoByModel";
 import { getInfoForTooltip } from "./utils/tooltipInfo";
 import { useTonieCardSaveFlow } from "./hooks/useTonieCardSaveFlow";
+import { useAssignNextEpisode } from "./hooks/useAssignNextEpisode";
 import { TooltipInfo, ValidateStatus } from "./TonieCardTypes";
 
 const api = new TeddyCloudApi(defaultAPIConfig());
@@ -214,6 +216,13 @@ export const TonieCard: React.FC<{
         addNotification,
         addLoadingNotification,
         closeLoadingNotification,
+        fetchUpdatedTonieCard,
+    });
+
+    const { nextEpisodeAvailable, handleAssignNextEpisode } = useAssignNextEpisode({
+        tonieCard,
+        overlay,
+        enabled: !readOnly,
         fetchUpdatedTonieCard,
     });
 
@@ -483,6 +492,26 @@ export const TonieCard: React.FC<{
         />
     );
 
+    const assignNextEpisodeAction = (
+        <Tooltip
+            title={
+                nextEpisodeAvailable
+                    ? t("tonies.assignNextEpisode.action")
+                    : t("tonies.assignNextEpisode.noneLeft")
+            }
+        >
+            <StepForwardOutlined
+                key="assignNextEpisode"
+                style={
+                    nextEpisodeAvailable
+                        ? undefined
+                        : { cursor: "default", color: token.colorTextDisabled }
+                }
+                onClick={nextEpisodeAvailable ? handleAssignNextEpisode : undefined}
+            />
+        </Tooltip>
+    );
+
     const languageCode = toLanguageCode(tonieCard.tonieInfo.language);
     const defaultLanguageCode = toLanguageCode(defaultLanguage);
     const languageTooltipKey = languageCode;
@@ -494,6 +523,7 @@ export const TonieCard: React.FC<{
               playAction,
               cloudAction,
               liveAction,
+              assignNextEpisodeAction,
           ];
 
     // ------------------------

--- a/src/components/tonies/toniecard/hooks/useAssignNextEpisode.ts
+++ b/src/components/tonies/toniecard/hooks/useAssignNextEpisode.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { TeddyCloudApi } from "../../../../api";
+import { defaultAPIConfig } from "../../../../config/defaultApiConfig";
+import { useTeddyCloud } from "../../../../provider/TeddyCloudProvider";
+import { NotificationTypeEnum } from "../../../../types/teddyCloudNotificationTypes";
+import { Record } from "../../../../types/fileBrowserTypes";
+import { TonieCardProps } from "../../../../types/tonieTypes";
+import { useAssignSourceToTonie } from "../../common/hooks/useAssignSourceToTonie";
+
+const api = new TeddyCloudApi(defaultAPIConfig());
+
+type UseAssignNextEpisodeParams = {
+    tonieCard: TonieCardProps;
+    overlay: string;
+    /** Skip fetching the folder listing entirely, e.g. for read-only card usages. */
+    enabled: boolean;
+    fetchUpdatedTonieCard: () => Promise<void>;
+};
+
+/**
+ * Determines and assigns the next not-yet-listened file (alphabetically, no wrap-around)
+ * in the library folder of the Tonie's currently assigned source file.
+ */
+export const useAssignNextEpisode = ({
+    tonieCard,
+    overlay,
+    enabled,
+    fetchUpdatedTonieCard,
+}: UseAssignNextEpisodeParams) => {
+    const { t } = useTranslation();
+    const { addNotification } = useTeddyCloud();
+    const { assignSourceToTonie } = useAssignSourceToTonie();
+
+    const [nextFile, setNextFile] = useState<Record | null>(null);
+    const [folder, setFolder] = useState<string>("");
+    const [loading, setLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        const source = tonieCard.source || "";
+        if (!enabled || !source.startsWith("lib://")) {
+            setNextFile(null);
+            setFolder("");
+            return;
+        }
+
+        const libPath = source.replace(/^lib:\/\//, "");
+        const lastSlash = libPath.lastIndexOf("/");
+        const sourceFolder = lastSlash >= 0 ? libPath.slice(0, lastSlash) : "";
+        const currentFileName = lastSlash >= 0 ? libPath.slice(lastSlash + 1) : libPath;
+
+        setFolder(sourceFolder);
+        setLoading(true);
+
+        let cancelled = false;
+        api.apiGetTeddyCloudApiRaw(
+            `/api/fileIndexV2?path=${sourceFolder}&special=library` +
+                (overlay ? `&overlay=${overlay}` : ""),
+        )
+            .then((response) => response.json())
+            .then((data: any) => {
+                if (cancelled) return;
+
+                const siblingFiles: Record[] = ((data.files || []) as Record[])
+                    .filter((file) => !file.isDir)
+                    .sort((a, b) => a.name.localeCompare(b.name));
+
+                const currentIndex = siblingFiles.findIndex((file) => file.name === currentFileName);
+                const candidates =
+                    currentIndex >= 0 ? siblingFiles.slice(currentIndex + 1) : siblingFiles;
+
+                setNextFile(candidates.find((file) => !file.listened) || null);
+            })
+            .catch(() => {
+                if (!cancelled) setNextFile(null);
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [tonieCard.source, overlay, enabled]);
+
+    const handleAssignNextEpisode = async () => {
+        if (!nextFile) return;
+
+        try {
+            await assignSourceToTonie(tonieCard, `lib://${folder}/${nextFile.name}`, overlay);
+            addNotification(
+                NotificationTypeEnum.Success,
+                t("tonies.assignNextEpisode.successMessage"),
+                t("tonies.assignNextEpisode.successDetails", { episode: nextFile.name }),
+                t("tonies.title"),
+            );
+            await fetchUpdatedTonieCard();
+        } catch (error) {
+            addNotification(
+                NotificationTypeEnum.Error,
+                t("tonies.assignNextEpisode.failedMessage"),
+                t("tonies.assignNextEpisode.failedDetails", { episode: nextFile.name }) + error,
+                t("tonies.title"),
+            );
+        }
+    };
+
+    return {
+        nextEpisodeAvailable: Boolean(nextFile),
+        loading,
+        handleAssignNextEpisode,
+    };
+};

--- a/src/types/fileBrowserTypes.ts
+++ b/src/types/fileBrowserTypes.ts
@@ -20,4 +20,5 @@ export type Record = {
     name: string;
     tafHeader: RecordTafHeader;
     tonieInfo: TonieInfo;
+    listened?: boolean;
 };


### PR DESCRIPTION
## Summary
- Adds a "mark as listened" toggle to each file row in the Library file browser
- Adds an "assign next episode" action to Tonie cards: finds the next
  not-yet-listened file (alphabetically, no wrap-around) in the current
  source file's library folder and assigns it to that Tonie
- Uses the new `/api/fileSetListened` endpoint and the new `listened`
  field on `/api/fileIndexV2`

## Requires
This PR requires the backend changes in toniebox-reverse-engineering/teddycloud#467
Without it, the toggle fails with a 404 and "assign next episode" never
finds a next file.

## Test plan
- [ ] Toggle icon appears on library file rows, colored when listened
- [ ] Toggling updates the flag and persists across reloads
- [ ] "Assign next episode" on a TonieCard is disabled when no unlistened file remains in the folder
- [ ] Clicking it assigns the correct next file and refreshes the card
- [ ] Tested against a local build of the paired backend branch (see companion PR)
