### PR TITLE
feat: assign library files directly to a Tonie tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - gui: Fixed bug malformed library post request [https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/171](https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/171)
 - gui: Added noopener noreferrer to external links [https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/308](https://github.com/toniebox-reverse-engineering/teddycloud_web/issues/308)
 - gui: Added tonies.custom.json snippet modal for getting skeleton of tonies.custom.json for all or selected tafs in current folder
+- gui: Added "assign to Tonie" action directly from the library file browser [https://github.com/toniebox-reverse-engineering/teddycloud_web/pull/318](https://github.com/toniebox-reverse-engineering/teddycloud_web/pull/318)
 
 ### Commits
 

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -315,6 +315,15 @@
     ],
     "fileBrowser": {
         "actions": "Aktionen",
+        "assignToTonie": {
+            "action": "Tonie zuweisen",
+            "failedDetails": "Zuweisung an \"{{series}}\" fehlgeschlagen: ",
+            "failedMessage": "Zuweisung fehlgeschlagen!",
+            "searchPlaceholder": "Tonies durchsuchen...",
+            "successDetails": "Datei erfolgreich \"{{series}}\" zugewiesen!",
+            "successMessage": "Tonie zugewiesen!",
+            "title": "Tonie zuweisen"
+        },
         "attention": "Bitte beachte!",
         "cancel": "Cancel",
         "confirmDeleteDialog": "Möchtest du die Datei {{fileToDelete}} wirklich löschen?",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -315,6 +315,15 @@
     ],
     "fileBrowser": {
         "actions": "Actions",
+        "assignToTonie": {
+            "action": "Assign to Tonie",
+            "failedDetails": "Could not assign \"{{series}}\" as content: ",
+            "failedMessage": "Assigning to Tonie failed!",
+            "searchPlaceholder": "Search Tonies...",
+            "successDetails": "File assigned to \"{{series}}\" successfully!",
+            "successMessage": "Tonie assigned!",
+            "title": "Assign to Tonie"
+        },
         "attention": "Please note!",
         "cancel": "Cancel",
         "confirmDeleteDialog": "Are you sure you want to delete {{fileToDelete}}?",

--- a/public/translations/es.json
+++ b/public/translations/es.json
@@ -315,6 +315,15 @@
     ],
     "fileBrowser": {
         "actions": "Acciones",
+        "assignToTonie": {
+            "action": "Asignar a Tonie",
+            "failedDetails": "No se pudo asignar a \"{{series}}\": ",
+            "failedMessage": "¡Error al asignar!",
+            "searchPlaceholder": "Buscar Tonies...",
+            "successDetails": "¡Archivo asignado a \"{{series}}\" correctamente!",
+            "successMessage": "¡Tonie asignado!",
+            "title": "Asignar a Tonie"
+        },
         "attention": "¡Atención!",
         "cancel": "Cancelar",
         "confirmDeleteDialog": "¿Estás seguro de que quieres eliminar {{fileToDelete}}?",

--- a/public/translations/fr.json
+++ b/public/translations/fr.json
@@ -315,6 +315,15 @@
     ],
     "fileBrowser": {
         "actions": "Actions",
+        "assignToTonie": {
+            "action": "Assigner à une Tonie",
+            "failedDetails": "Impossible d'assigner à \"{{series}}\" : ",
+            "failedMessage": "Échec de l'assignation !",
+            "searchPlaceholder": "Rechercher des Tonies...",
+            "successDetails": "Fichier assigné à \"{{series}}\" avec succès !",
+            "successMessage": "Tonie assignée !",
+            "title": "Assigner à une Tonie"
+        },
         "attention": "Veuillez noter !",
         "cancel": "Annuler",
         "confirmDeleteDialog": "Êtes-vous sûr de vouloir supprimer {{fileToDelete}}?",

--- a/src/components/tonies/common/hooks/useAssignSourceToTonie.ts
+++ b/src/components/tonies/common/hooks/useAssignSourceToTonie.ts
@@ -1,0 +1,26 @@
+import { TeddyCloudApi } from "../../../../api";
+import { defaultAPIConfig } from "../../../../config/defaultApiConfig";
+import { TonieCardProps } from "../../../../types/tonieTypes";
+
+const api = new TeddyCloudApi(defaultAPIConfig());
+
+/**
+ * Assign a "lib://" or "http(s)://" source path to a Tonie tag, mirroring
+ * useTonieCardSaveFlow.handleSourceSave (source + nocloud + live follow-up).
+ */
+export const useAssignSourceToTonie = () => {
+    const assignSourceToTonie = async (tonieCard: TonieCardProps, path: string, overlay: string) => {
+        await api.apiPostTeddyCloudContentJson(tonieCard.ruid, "source=" + encodeURIComponent(path), overlay);
+
+        if (!tonieCard.nocloud) {
+            await api.apiPostTeddyCloudContentJson(tonieCard.ruid, "nocloud=true", overlay);
+        }
+
+        const shouldBeLive = path.startsWith("http");
+        if (shouldBeLive !== tonieCard.live) {
+            await api.apiPostTeddyCloudContentJson(tonieCard.ruid, "live=" + shouldBeLive, overlay);
+        }
+    };
+
+    return { assignSourceToTonie };
+};

--- a/src/components/tonies/common/modals/AssignTonieModal.tsx
+++ b/src/components/tonies/common/modals/AssignTonieModal.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Input, List, Modal, Typography } from "antd";
+
+import { TonieCardProps } from "../../../../types/tonieTypes";
+import { NotificationTypeEnum } from "../../../../types/teddyCloudNotificationTypes";
+import { useTeddyCloud } from "../../../../provider/TeddyCloudProvider";
+import { useTonieboxContentOverlay } from "../../../../hooks/useTonieboxContentOverlay";
+import { useTonies } from "../../../../hooks/useTonies";
+import { useAssignSourceToTonie } from "../hooks/useAssignSourceToTonie";
+import { toImageSrc } from "../utils/imagePathUtils";
+import ThumbnailCell from "../elements/ThumbnailCell";
+import LoadingSpinner from "../../../common/elements/LoadingSpinner";
+
+const { Text } = Typography;
+
+interface AssignTonieModalProps {
+    open: boolean;
+    onClose: () => void;
+    /** The lib:// path (already prefixed) of the file being assigned. */
+    sourcePath: string;
+    onAssigned?: () => void;
+}
+
+/**
+ * Lightweight, list-based Tonie tag picker used to assign a library file as a Tonie's
+ * content directly from the Library file browser. Deliberately kept smaller than
+ * ToniesList.tsx, which is built for the full Tonies overview page.
+ */
+export const AssignTonieModal: React.FC<AssignTonieModalProps> = ({
+    open,
+    onClose,
+    sourcePath,
+    onAssigned,
+}) => {
+    const { t } = useTranslation();
+    const { addNotification } = useTeddyCloud();
+    const { overlay } = useTonieboxContentOverlay();
+    const { assignSourceToTonie } = useAssignSourceToTonie();
+
+    const [filterText, setFilterText] = useState("");
+    const [assigningRuid, setAssigningRuid] = useState<string | null>(null);
+
+    const sourceFolder = sourcePath.slice(0, sourcePath.lastIndexOf("/") + 1);
+
+    const sortByFolderMatch = (a: TonieCardProps, b: TonieCardProps) => {
+        const aMatches = (a.source || "").startsWith(sourceFolder) ? 1 : 0;
+        const bMatches = (b.source || "").startsWith(sourceFolder) ? 1 : 0;
+        return bMatches - aMatches;
+    };
+
+    const { tonies, loading } = useTonies({
+        overlay: overlay ?? "",
+        merged: false,
+        filter: "tag",
+        sort: sortByFolderMatch,
+    });
+
+    const filteredTonies = useMemo(() => {
+        const text = filterText.trim().toLowerCase();
+        if (!text) return tonies;
+        return tonies.filter((tonie) => {
+            const title = `${tonie.tonieInfo.series} ${tonie.tonieInfo.episode}`.toLowerCase();
+            return title.includes(text);
+        });
+    }, [tonies, filterText]);
+
+    const handleAssign = async (tonieCard: TonieCardProps) => {
+        setAssigningRuid(tonieCard.ruid);
+        try {
+            await assignSourceToTonie(tonieCard, sourcePath, overlay ?? "");
+            addNotification(
+                NotificationTypeEnum.Success,
+                t("fileBrowser.assignToTonie.successMessage"),
+                t("fileBrowser.assignToTonie.successDetails", {
+                    series: tonieCard.tonieInfo.series || tonieCard.uid,
+                }),
+                t("fileBrowser.title"),
+            );
+            onAssigned?.();
+            onClose();
+        } catch (error) {
+            addNotification(
+                NotificationTypeEnum.Error,
+                t("fileBrowser.assignToTonie.failedMessage"),
+                t("fileBrowser.assignToTonie.failedDetails", {
+                    series: tonieCard.tonieInfo.series || tonieCard.uid,
+                }) + error,
+                t("fileBrowser.title"),
+            );
+        } finally {
+            setAssigningRuid(null);
+        }
+    };
+
+    return (
+        <Modal
+            title={t("fileBrowser.assignToTonie.title")}
+            open={open}
+            onCancel={onClose}
+            footer={null}
+        >
+            <Input
+                placeholder={t("fileBrowser.assignToTonie.searchPlaceholder")}
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                allowClear
+                autoFocus
+                style={{ marginBottom: 12 }}
+            />
+            {loading ? (
+                <LoadingSpinner />
+            ) : (
+                <List
+                    style={{ maxHeight: 420, overflowY: "auto" }}
+                    dataSource={filteredTonies}
+                    rowKey={(tonie) => tonie.ruid}
+                    renderItem={(tonie) => (
+                        <List.Item
+                            style={{ cursor: "pointer", opacity: assigningRuid ? 0.6 : 1 }}
+                            onClick={() => (assigningRuid ? undefined : handleAssign(tonie))}
+                        >
+                            <List.Item.Meta
+                                avatar={
+                                    <ThumbnailCell
+                                        src={toImageSrc(tonie.tonieInfo.picture)}
+                                        alt={tonie.tonieInfo.series}
+                                    />
+                                }
+                                title={tonie.tonieInfo.series || t("tonies.unsetTonie")}
+                                description={
+                                    <Text type="secondary">{tonie.tonieInfo.episode || tonie.uid}</Text>
+                                }
+                            />
+                        </List.Item>
+                    )}
+                />
+            )}
+        </Modal>
+    );
+};
+
+export default AssignTonieModal;

--- a/src/components/tonies/filebrowser/FileBrowser.tsx
+++ b/src/components/tonies/filebrowser/FileBrowser.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from "react-router-dom";
 
 import TeddyAudioPlaylistEditor from "./modals/TeddyAudioPlaylistEditorModal";
 import TonieInformationModal from "../common/modals/TonieInformationModal";
+import { AssignTonieModal } from "../common/modals/AssignTonieModal";
 
 import { IMAGE_EXTENSIONS } from "../../../constants/fileTypes";
 import { ffmpegSupportedExtensions } from "../../../utils/files/ffmpegSupportedExtensions";
@@ -101,6 +102,9 @@ export const FileBrowser: React.FC<{
 
     const [isMoveFileModalOpen, setIsMoveFileModalOpen] = useState<boolean>(false);
     const [isRenameFileModalOpen, setIsRenameFileModalOpen] = useState<boolean>(false);
+
+    const [isAssignTonieModalOpen, setIsAssignTonieModalOpen] = useState<boolean>(false);
+    const [assignTonieSourcePath, setAssignTonieSourcePath] = useState<string>("");
 
     const [isOpenUploadDragAndDropModal, setIsOpenUploadDragAndDropModal] =
         useState<boolean>(false);
@@ -269,6 +273,17 @@ export const FileBrowser: React.FC<{
         setIsRenameFileModalOpen(false);
     };
 
+    // assign to tonie
+    const showAssignTonieDialog = (record: Record) => {
+        const normalizedPath = path === "" || path.endsWith("/") ? path : `${path}/`;
+        setAssignTonieSourcePath(`lib://${normalizedPath}${record.name}`);
+        setIsAssignTonieModalOpen(true);
+    };
+
+    const closeAssignTonieModal = () => {
+        setIsAssignTonieModalOpen(false);
+    };
+
     // encode files
     const showFileEncodeModal = () => {
         setTreeNodeId(rootTreeNode.id);
@@ -375,6 +390,7 @@ export const FileBrowser: React.FC<{
         showRenameDialog,
         showMoveDialog,
         showDeleteConfirmDialog,
+        showAssignTonieDialog,
         buildContentUrl: special === "custom_img" ? buildContentUrl : undefined,
         onImagePreviewClick:
             special === "custom_img"
@@ -485,6 +501,14 @@ export const FileBrowser: React.FC<{
                     path={path}
                     currentFile={currentFile || null}
                     setRebuildList={setRebuildList}
+                />
+            )}
+            {isAssignTonieModalOpen && (
+                <AssignTonieModal
+                    open={isAssignTonieModalOpen}
+                    onClose={closeAssignTonieModal}
+                    sourcePath={assignTonieSourcePath}
+                    onAssigned={() => setRebuildList((prev) => !prev)}
                 />
             )}
             {isEncodeFilesModalOpen && (

--- a/src/components/tonies/filebrowser/helper/Columns.tsx
+++ b/src/components/tonies/filebrowser/helper/Columns.tsx
@@ -12,6 +12,7 @@ import {
     NodeExpandOutlined,
     DeleteOutlined,
     LoadingOutlined,
+    SwapOutlined,
 } from "@ant-design/icons";
 
 import { IMAGE_EXTENSIONS } from "../../../../constants/fileTypes";
@@ -76,6 +77,7 @@ export interface CreateColumnsOptions {
     showRenameDialog?: (fileName: string) => void;
     showMoveDialog?: (fileName: string) => void;
     showDeleteConfirmDialog?: (fileName: string, fullPath: string, query: string) => void;
+    showAssignTonieDialog?: (record: Record) => void;
     buildContentUrl?: (fileName: string, options?: { ogg?: boolean }) => string;
     onImagePreviewClick?: (imageUrl: string) => void;
     onRowSelect?: (record: Record) => void;
@@ -111,6 +113,7 @@ export const createColumns = (options: CreateColumnsOptions): any[] => {
         showRenameDialog,
         showMoveDialog,
         showDeleteConfirmDialog,
+        showAssignTonieDialog,
         buildContentUrl,
         onImagePreviewClick,
         onRowSelect,
@@ -657,6 +660,23 @@ export const createColumns = (options: CreateColumnsOptions): any[] => {
                 }
 
                 if ((special === "library" || special === "custom_img") && record.name !== "..") {
+                    if (!record.isDir && special === "library" && showAssignTonieDialog) {
+                        actions.push(
+                            <Tooltip
+                                open={!canHover ? false : undefined}
+                                key={`action-assign-${record.name}`}
+                                title={t("fileBrowser.assignToTonie.action")}
+                            >
+                                <SwapOutlined
+                                    onClick={() => showAssignTonieDialog(record)}
+                                    style={{
+                                        margin: "4px 8px 4px 0",
+                                        padding: 4,
+                                    }}
+                                />
+                            </Tooltip>,
+                        );
+                    }
                     if (!record.isDir && showRenameDialog) {
                         actions.push(
                             <Tooltip


### PR DESCRIPTION
## Summary
- Adds an "assign to Tonie" action to each file row in the Library file browser
- Opens a lightweight Tonie picker (search field, thumbnails) instead of
  having to go through a Tonie's edit modal and browse for the file there
- Tonies that already have a file assigned from the same library folder are
  sorted to the top of the picker
- Assigns via the existing content.json `source=` API, same call the
  Tonie edit modal already uses — no backend changes needed

## Test plan
- [ ] "Assign to Tonie" icon appears on library file rows
- [ ] Picker opens, shows all Tonies, search filters by series/episode
- [ ] Tonies with a file from the same folder appear first
- [ ] Clicking a Tonie assigns the file as its source and closes the modal
